### PR TITLE
[MOB-1074] Add back redirect payment methods to the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Airwallex Android SDK Changelog
 All notable changes to the SDK will be documented in this file.
 
+## Version 4.0.4 (Sep 8, 2022)
+- Fix missing payment methods
+
 ## Version 4.0.3 (Aug 26, 2022)
 - Support card saving in payment session
 - Remove duplicate cards

--- a/GUIDE-zh.md
+++ b/GUIDE-zh.md
@@ -64,12 +64,12 @@ Airwallex Android SDK 支持Android API 19及以上版本。
 ```groovy
     dependencies {
         // It's required
-        implementation 'io.github.airwallex:payment:4.0.3'
+        implementation 'io.github.airwallex:payment:4.0.4'
         
         // Select the payment method you want to support.
-        implementation 'io.github.airwallex:payment-card:4.0.3'
-        implementation 'io.github.airwallex:payment-redirect:4.0.3'
-        implementation 'io.github.airwallex:payment-wechat:4.0.3'
+        implementation 'io.github.airwallex:payment-card:4.0.4'
+        implementation 'io.github.airwallex:payment-redirect:4.0.4'
+        implementation 'io.github.airwallex:payment-wechat:4.0.4'
     }
 ```
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -64,12 +64,12 @@ To install the SDK, in your app-level `build.gradle`, add the following:
 ```groovy
     dependencies {
         // It's required
-        implementation 'io.github.airwallex:payment:4.0.3'
+        implementation 'io.github.airwallex:payment:4.0.4'
         
         // Select the payment method you want to support.
-        implementation 'io.github.airwallex:payment-card:4.0.3'
-        implementation 'io.github.airwallex:payment-redirect:4.0.3'
-        implementation 'io.github.airwallex:payment-wechat:4.0.3'
+        implementation 'io.github.airwallex:payment-card:4.0.4'
+        implementation 'io.github.airwallex:payment-redirect:4.0.4'
+        implementation 'io.github.airwallex:payment-wechat:4.0.4'
     }
 ```
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -14,7 +14,7 @@ Airwallx Android SDK 可以很方便得在你的Android用用中添加支付功�
 在 `build.gradle`中添加以下依赖
 ```groovy
 dependencies {
-    implementation 'io.github.airwallex:payment:4.0.3'
+    implementation 'io.github.airwallex:payment:4.0.4'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Components are available through [Maven Central](https://repo1.maven.org/mav
 Add the dependency in your `build.gradle`.
 ```groovy
 dependencies {
-    implementation 'io.github.airwallex:payment:4.0.3'
+    implementation 'io.github.airwallex:payment:4.0.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ task clean(type: Delete) {
 }
 
 // Update the version field when a new version is released
-version = '4.0.3'
+version = '4.0.4'
 
 ext {
     compileSdkVersion = 31

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPlugins.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPlugins.kt
@@ -35,6 +35,9 @@ object AirwallexPlugins {
 
     @Suppress("SwallowedException")
     fun getProvider(paymentMethodType: AvailablePaymentMethodType): ActionComponentProvider<out ActionComponent>? {
+        if (paymentMethodType.resources?.hasSchema == true) {
+            return getProvider(ActionComponentProviderType.REDIRECT)
+        }
         return try {
             getProvider(ActionComponentProviderType.valueOf(paymentMethodType.name.uppercase()))
         } catch (e: IllegalArgumentException) {

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
@@ -4,19 +4,20 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.airwallex.android.core.model.AvailablePaymentMethodType
+import com.airwallex.android.core.model.AvailablePaymentMethodTypeResource
 import com.airwallex.android.core.model.NextAction
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class AirwallexPluginsTest {
-    private class TestComponentProvider : ActionComponentProvider<TestComponnent> {
+    private class TestComponentProvider(val providerType: ActionComponentProviderType) : ActionComponentProvider<TestComponnent> {
         override fun get(): TestComponnent {
             return TestComponnent()
         }
 
         override fun getType(): ActionComponentProviderType {
-            return ActionComponentProviderType.GOOGLEPAY
+            return providerType
         }
 
         override fun canHandleAction(nextAction: NextAction?): Boolean {
@@ -66,12 +67,12 @@ class AirwallexPluginsTest {
     }
 
     @Test
-    fun `test get action component provider`() {
+    fun `test get Google Pay action component provider`() {
         AirwallexPlugins.initialize(
             AirwallexConfiguration.Builder()
                 .setSupportComponentProviders(
                     listOf(
-                        TestComponentProvider()
+                        TestComponentProvider(ActionComponentProviderType.GOOGLEPAY)
                     )
                 )
                 .build()
@@ -83,6 +84,28 @@ class AirwallexPluginsTest {
                 )
             )?.getType(),
             ActionComponentProviderType.GOOGLEPAY
+        )
+    }
+
+    @Test
+    fun `test get redirect action component provider`() {
+        AirwallexPlugins.initialize(
+            AirwallexConfiguration.Builder()
+                .setSupportComponentProviders(
+                    listOf(
+                        TestComponentProvider(ActionComponentProviderType.REDIRECT)
+                    )
+                )
+                .build()
+        )
+        assertEquals(
+            AirwallexPlugins.getProvider(
+                AvailablePaymentMethodType(
+                    name = "alipaycn",
+                    resources = AvailablePaymentMethodTypeResource(true)
+                )
+            )?.getType(),
+            ActionComponentProviderType.REDIRECT
         )
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -115,10 +115,10 @@ dependencies {
     api project(':redirect')
     api project(':googlepay')
 
-//    implementation 'io.github.airwallex:payment:4.0.3'
-//    implementation 'io.github.airwallex:payment-card:4.0.3'
-//    implementation 'io.github.airwallex:payment-redirect:4.0.3'
-//    implementation 'io.github.airwallex:payment-wechat:4.0.3'
+//    implementation 'io.github.airwallex:payment:4.0.4'
+//    implementation 'io.github.airwallex:payment-card:4.0.4'
+//    implementation 'io.github.airwallex:payment-redirect:4.0.4'
+//    implementation 'io.github.airwallex:payment-wechat:4.0.4'
 
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'


### PR DESCRIPTION
Following the iOS logic, use redirect action component when `hasSchema` is `true`. After fix:
 
<img src="https://user-images.githubusercontent.com/107159278/189046440-8bc39d51-0bd7-48a1-a39f-a053ad19d198.png" width=200>
