### PR TITLE
[MOB-1038] Google pay update billing and naming

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -171,7 +171,7 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
                     googlePayOptions = GooglePayOptions(
                         billingAddressRequired = true,
                         billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
-                        merchantId = "12345678"
+                        merchantId = {PUBLIC_MERCHANT_ID}
                     )
                 )
                     .setReturnUrl(Settings.returnUrl)
@@ -252,7 +252,7 @@ The Airwallex Android SDK allows merchants to provide Google Pay as a payment me
 ```
 val googlePayOptions = GooglePayOptions(
         allowedCardAuthMethods = listOf("3DS"),
-        merchantId = "12345678",
+        merchantId = {PUBLIC_MERCHANT_ID},
         billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
         shippingAddressParameters = ShippingAddressParameters(listOf("AU", "CN"), true)
     )

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -70,6 +70,7 @@ To install the SDK, in your app-level `build.gradle`, add the following:
         implementation 'io.github.airwallex:payment-card:4.0.4'
         implementation 'io.github.airwallex:payment-redirect:4.0.4'
         implementation 'io.github.airwallex:payment-wechat:4.0.4'
+        implementation 'io.github.airwallex:payment-googlepay:4.0.4'
     }
 ```
 
@@ -87,7 +88,8 @@ We provide some parameters that can be used to debug the SDK, you can call it in
                 listOf(
                     CardComponent.PROVIDER,
                     WeChatComponent.PROVIDER,
-                    RedirectComponent.PROVIDER
+                    RedirectComponent.PROVIDER,
+                    GooglePayComponent.PROVIDER
                 )
             )
             .build(),
@@ -165,7 +167,12 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
                         paymentIntent,
                         { "PaymentIntent is required" }
                     ),
-                    countryCode = Settings.countryCode
+                    countryCode = Settings.countryCode,
+                    googlePayOptions = GooglePayOptions(
+                        billingAddressRequired = true,
+                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
+                        merchantId = "12345678"
+                    )
                 )
                     .setReturnUrl(Settings.returnUrl)
                     .build()
@@ -235,6 +242,29 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
         }
     )
 ```
+
+### Set up Google Pay
+The Airwallex Android SDK allows merchants to provide Google Pay as a payment method to their customers by the following steps:
+- Make sure Google Pay is enabled on your Airwallex account.
+- Include the Google Pay module when installing the SDK as per [Step1](#step1-set-up-sdk).
+- [Create a payments profile](https://support.google.com/paymentscenter/answer/7161426) and get the [Merchant ID](https://support.google.com/googleplay/android-developer/answer/7163092), and use it to configure `googlePayOptions` on the payment session object. 
+- You can customize the Google Pay options to restrict as well as provide extra context. For more information, please refer to `GooglePayOptions` class.
+```
+val googlePayOptions = GooglePayOptions(
+        allowedCardAuthMethods = listOf("3DS"),
+        merchantId = "12345678",
+        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
+        shippingAddressParameters = ShippingAddressParameters(listOf("AU", "CN"), true)
+    )
+val paymentSession = AirwallexPaymentSession.Builder(
+        paymentIntent = ...,
+        countryCode = ...,
+        googlePayOptions = googlePayOptions
+    )
+```
+- We currently only support Visa and MasterCard for Google Pay, customers will only be able to select the cards of these payment networks during Google Pay.
+> Please note that our Google Pay module only supports `AirwallexPaymentSession` at the moment. We'll add support for recurring payment sessions in the future.
+
 ### Custom Theme
 You can overwrite these color values in your app. https://developer.android.com/guide/topics/ui/look-and-feel/themes#CustomizeTheme
 ```
@@ -251,7 +281,7 @@ To run the example project, you should follow these steps.
 
 2. Open Android Studio and import the project by selecting the `build.gradle` file from the cloned repository
 
-3. Goto [Airwallex Account settings > API keys](https://www.airwallex.com/app/settings/api), then copy `Client ID` and` API key` to [`Settings.kt`](https://github.com/airwallex/airwallex-payment-android/blob/master/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt)
+3. Go to [Airwallex Account settings > API keys](https://www.airwallex.com/app/settings/api), then copy `Client ID` and` API key` to [`Settings.kt`](https://github.com/airwallex/airwallex-payment-android/blob/master/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt)
 ```
     private const val BASE_URL = "put your base url here"
     private const val API_KEY = "put your api key here"

--- a/airwallex/src/main/java/com/airwallex/android/view/CardExpiryEditText.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/CardExpiryEditText.kt
@@ -39,7 +39,7 @@ internal class CardExpiryEditText @JvmOverloads constructor(
             return try {
                 Pair(
                     dateFields[0].toInt(),
-                    dateFields[1].toInt()
+                    "20${dateFields[1]}".toInt()
                 )
             } catch (numEx: NumberFormatException) {
                 null

--- a/airwallex/src/test/java/com/airwallex/android/view/CardExpiryEditTextTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardExpiryEditTextTest.kt
@@ -72,4 +72,10 @@ class CardExpiryEditTextTest {
         cardExpiryEditText.setText("12/2023")
         assertTrue(hasError)
     }
+
+    @Test
+    fun testValidDateFields() {
+        cardExpiryEditText.setText("12/23")
+        assertEquals(cardExpiryEditText.validDateFields, Pair(12, 2023))
+    }
 }

--- a/airwallex/src/test/java/com/airwallex/android/view/CardWidgetTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardWidgetTest.kt
@@ -68,7 +68,7 @@ class CardWidgetTest {
                 .setNumber("4242424242424242")
                 .setCvc("123")
                 .setExpiryMonth("10")
-                .setExpiryYear("23")
+                .setExpiryYear("2023")
                 .build(),
             cardWidget.paymentMethodCard
         )

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -1041,7 +1041,6 @@ class Airwallex internal constructor(
         const val AIRWALLEX_CHECKOUT_SCHEMA = "airwallexcheckout"
         private val unsupportedPaymentMethodTypes = listOf(
             "applepay",
-            "googlepay", // todo: remove once integrated
             "ach_direct_debit", // todo: remove once mandate is rendered properly
             "becs_direct_debit", // todo: remove once mandate is rendered properly
             "sepa_direct_debit", // todo: remove once mandate is rendered properly

--- a/components-core/src/main/java/com/airwallex/android/core/model/PaymentMethodRequest.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/model/PaymentMethodRequest.kt
@@ -45,18 +45,25 @@ class PaymentMethodRequest(
                 mapOf(PaymentMethodParser.FIELD_TYPE to type)
             )
             .plus(
-                paymentRequest?.let {
-                    mapOf(type to it.toParamMap())
+                paymentRequest?.let { request ->
+                    mapOf(
+                        type to request.toParamMap().plus(
+                            billing?.let {
+                                mapOf(PaymentMethodParser.FIELD_BILLING to it.toParamMap())
+                            }.orEmpty()
+                        )
+                    )
                 }.orEmpty()
             )
             .plus(
-                card?.let {
-                    mapOf(PaymentMethodParser.FIELD_CARD to it.toParamMap())
-                }.orEmpty()
-            )
-            .plus(
-                billing?.let {
-                    mapOf(PaymentMethodParser.FIELD_BILLING to it.toParamMap())
+                card?.let { card ->
+                    mapOf(
+                        PaymentMethodParser.FIELD_CARD to card.toParamMap().plus(
+                            billing?.let {
+                                mapOf(PaymentMethodParser.FIELD_BILLING to it.toParamMap())
+                            }.orEmpty()
+                        )
+                    )
                 }.orEmpty()
             )
     }

--- a/components-core/src/test/java/com/airwallex/android/core/model/PaymentMethodRequestTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/PaymentMethodRequestTest.kt
@@ -47,7 +47,7 @@ class PaymentMethodRequestTest {
     }
 
     @Test
-    fun testSetGooglePayPaymentMethodRequest() {
+    fun testGooglePayPaymentMethodRequest() {
         val request = PaymentMethodRequest.Builder("googlepay")
             .setGooglePayPaymentMethodRequest(
                 mapOf("payment_data_type" to "encrypted_payment_token"),
@@ -57,11 +57,55 @@ class PaymentMethodRequestTest {
                 )
             )
             .build()
+        val paramMap = request.toParamMap()
         assertEquals(request.billing?.firstName, "John")
         assertEquals(request.billing?.lastName, "Citizen")
         assertEquals(
             request.paymentRequest?.additionalInfo,
             mapOf("payment_data_type" to "encrypted_payment_token")
+        )
+        assertEquals(
+            mapOf(
+                "type" to "googlepay",
+                "googlepay" to mapOf(
+                    "billing" to mapOf(
+                        "first_name" to "John",
+                        "last_name" to "Citizen"
+                    ),
+                    "payment_data_type" to "encrypted_payment_token",
+                    "flow" to "inapp",
+                    "os_type" to "android"
+                )
+            ),
+            paramMap
+        )
+    }
+
+    @Test
+    fun testCardPaymentMethodRequest() {
+        val paramMap = PaymentMethodRequest.Builder("card")
+            .setCardPaymentMethodRequest(
+                PaymentMethod.Card(cvc = "686"),
+                Billing(
+                    firstName = "John",
+                    lastName = "Citizen"
+                )
+            )
+            .build()
+            .toParamMap()
+
+        assertEquals(
+            mapOf(
+                "type" to "card",
+                "card" to mapOf(
+                    "billing" to mapOf(
+                        "first_name" to "John",
+                        "last_name" to "Citizen"
+                    ),
+                    "cvc" to "686"
+                )
+            ),
+            paramMap
         )
     }
 }

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
@@ -294,8 +294,8 @@ object PaymentsUtil {
                         .setStreet(street)
                         .build()
                 )
-                .setFirstName(name.split(" ").firstOrNull())
-                .setLastName(name.split(" ").getOrNull(1))
+                .setFirstName(name.split(" ").firstOrNull() ?: "")
+                .setLastName(name.split(" ").getOrNull(1) ?: "")
                 .setEmail(payload.optString("email", null))
                 .build()
         } else {

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
@@ -276,18 +276,18 @@ object PaymentsUtil {
 
     fun getBilling(payload: JSONObject): Billing? {
         val name = payload.optString("name")
-        val locality = payload.optString("locality")
         val countryCode = payload.optString("countryCode")
-        if (name.isNotEmpty() && locality.isNotEmpty() && countryCode.isNotEmpty()) {
+        if (name.isNotEmpty() && countryCode.isNotEmpty()) {
             val street = listOf(
                 payload.optString("address1"),
                 payload.optString("address2"),
                 payload.optString("address3")
             ).filterNot { it.isEmpty() }.joinToString(" ")
+            val locality = payload.optString("locality").takeIf { it.isNotEmpty() }
             return Billing.Builder()
                 .setAddress(
                     Address.Builder()
-                        .setCity(locality)
+                        .setCity(locality ?: countryCode)
                         .setCountryCode(countryCode)
                         .setPostcode(payload.optString("postalCode", null))
                         .setState(payload.optString("administrativeArea", null))

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
@@ -8,7 +8,6 @@ import com.airwallex.android.core.model.Billing
 import com.airwallex.android.core.model.CardScheme
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Test
 import java.math.BigDecimal
 

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
@@ -153,4 +153,18 @@ class PaymentsUtilTest {
         assertEquals(PaymentsUtil.getBilling(json)?.firstName, "John")
         assertEquals(PaymentsUtil.getBilling(json)?.lastName, "")
     }
+
+    @Test
+    fun `test getBilling city when locality is empty`() {
+        val json = JSONObject(
+            """
+                {
+                "countryCode":"HK",
+                "locality":"",
+                "name":"John"
+                }
+            """.trimIndent()
+        )
+        assertEquals(PaymentsUtil.getBilling(json)?.address?.city, "HK")
+    }
 }

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
@@ -8,6 +8,7 @@ import com.airwallex.android.core.model.Billing
 import com.airwallex.android.core.model.CardScheme
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import java.math.BigDecimal
 
@@ -135,5 +136,22 @@ class PaymentsUtilTest {
             .setLastName("Citizen")
             .build()
         )
+    }
+
+    @Test
+    fun `test getBilling when name does not have space`() {
+        val json = JSONObject(
+            """
+                {
+                "address2":"Unit 4214",
+                "administrativeArea":"VIC",
+                "countryCode":"AU",
+                "locality":"Melbourne",
+                "name":"John"
+                }
+            """.trimIndent()
+        )
+        assertEquals(PaymentsUtil.getBilling(json)?.firstName, "John")
+        assertEquals(PaymentsUtil.getBilling(json)?.lastName, "")
     }
 }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -157,7 +157,7 @@ class PaymentCartFragment : Fragment() {
                     googlePayOptions = GooglePayOptions(
                         billingAddressRequired = true,
                         billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
-                        merchantId = Settings.accountId
+                        merchantId = "423102959764541877"
                     )
                 )
                     .setReturnUrl(Settings.returnUrl)


### PR DESCRIPTION
This Pr is to clear up following chores before Google Pay release:

1. Make first/last name empty string if can't get it from `name` response from google pay api
2. Move billing info inside payment method field in confirm intent request
3. Hardcode expiry year with `20` (align with web) as backend needs full `YYYY` digits.
4. Use country code as city if `locality` is missing from google pay api
5. Enable and add Readme for Google Pay module