### PR TITLE
fix: decoding flows of available payment method properly

### DIFF
--- a/airwallex/src/test/java/com/airwallex/android/view/PaymentMethodsViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/PaymentMethodsViewModelTest.kt
@@ -65,7 +65,7 @@ class PaymentMethodsViewModelTest {
                    "transaction_mode":${transactionMode.value},
                    "active":true,
                    "transaction_currencies":["dollar","RMB"],
-                   "flows":["IN_APP"]
+                   "flows":["inapp"]
                   }   
             ],
             "has_more":false

--- a/components-core/src/main/java/com/airwallex/android/core/model/parser/AvailablePaymentMethodTypeParser.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/model/parser/AvailablePaymentMethodTypeParser.kt
@@ -21,7 +21,7 @@ class AvailablePaymentMethodTypeParser : ModelJsonParser<AvailablePaymentMethodT
             ),
             flows = AirwallexJsonUtils.jsonArrayToList(json.optJSONArray(FIELD_FLOWS))
                 .orEmpty()
-                .map { AirwallexPaymentRequestFlow.valueOf(it.toString()) },
+                .mapNotNull { AirwallexPaymentRequestFlow.fromValue(it.toString()) },
             transactionCurrencies = ModelJsonParser.jsonArrayToList(
                 json.optJSONArray(FIELD_TRANSACTION_CURRENCIES)
             ),

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentManagerTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentManagerTest.kt
@@ -21,7 +21,7 @@ class AirwallexPaymentManagerTest {
                    "transaction_mode":"oneoff",
                    "active":true,
                    "transaction_currencies":["dollar","RMB"],
-                   "flows":["IN_APP"]
+                   "flows":["inapp"]
                   }   
             ],
             "has_more":false

--- a/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodFixtures.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodFixtures.kt
@@ -12,7 +12,7 @@ internal object AvailablePaymentMethodFixtures {
             "transaction_mode":"oneoff",
             "active":true,
             "transaction_currencies":["dollar","RMB"],
-            "flows":["IN_APP"]
+            "flows":["inapp"]
         }
             """.trimIndent()
         )

--- a/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodResponseFixtures.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodResponseFixtures.kt
@@ -14,7 +14,7 @@ internal object AvailablePaymentMethodResponseFixtures {
                    "transaction_mode":"oneoff",
                    "active":true,
                    "transaction_currencies":["dollar","RMB"],
-                   "flows":["IN_APP"]
+                   "flows":["inapp"]
                   }   
             ],
             "has_more":false

--- a/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodTypeParserTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/AvailablePaymentMethodTypeParserTest.kt
@@ -18,7 +18,7 @@ class AvailablePaymentMethodTypeParserTest {
         "active":true,
         "transaction_currencies":["dollar","RMB"],
         "country_codes":["CN","AU"],
-        "flows":["IN_APP"],
+        "flows":["inapp", "mweb"],
         "resources": {
         "has_schema": false,
         "logos": {
@@ -49,7 +49,10 @@ class AvailablePaymentMethodTypeParserTest {
         assertEquals(availablePaymentMethodType.active, true)
         assertEquals(availablePaymentMethodType.transactionCurrencies, listOf("dollar", "RMB"))
         assertEquals(availablePaymentMethodType.countryCodes, listOf("CN", "AU"))
-        assertEquals(availablePaymentMethodType.flows, listOf(AirwallexPaymentRequestFlow.IN_APP))
+        assertEquals(
+            availablePaymentMethodType.flows,
+            listOf(AirwallexPaymentRequestFlow.IN_APP, AirwallexPaymentRequestFlow.M_WEB)
+        )
         assertEquals(availablePaymentMethodType.resources?.hasSchema, false)
         assertEquals(
             availablePaymentMethodType.resources?.logos?.png,

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentProviderTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentProviderTest.kt
@@ -55,7 +55,7 @@ class GooglePayComponentProviderTest {
                    "transaction_mode":"oneoff",
                    "active":true,
                    "transaction_currencies":["dollar","RMB"],
-                   "flows":["IN_APP"],
+                   "flows":["inapp"],
                    "card_schemes":[{ "name": "mastercard" }]
                     }   
                     ],

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
@@ -40,7 +40,7 @@ class GooglePayComponentTest {
                    "transaction_mode":"oneoff",
                    "active":true,
                    "transaction_currencies":["dollar","RMB"],
-                   "flows":["IN_APP"],
+                   "flows":["inapp"],
                    "card_schemes":[{ "name": "mastercard" }]
                     }   
                     ],


### PR DESCRIPTION
This pr fixes:
<img width="200" alt="image (1)" src="https://user-images.githubusercontent.com/107159278/192417569-b107ddb7-96d6-4372-b474-6012c54dae74.png">

So that the value expected for `flows` will only be `inapp` and `mweb`, and we'll ignore values other than these two instead of throwing exception.
