### PR TITLE
[NM-1085] Set status as in progress when wechat is launched

### DIFF
--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -351,6 +351,7 @@ class PaymentCartFragment : Fragment() {
                     is AirwallexPaymentStatus.InProgress -> {
                         // redirecting
                         Log.d(TAG, "Payment is redirecting ${it.paymentIntentId}")
+                        showPaymentInProgress()
                     }
                     is AirwallexPaymentStatus.Failure -> {
                         showPaymentError(it.exception.message)
@@ -599,6 +600,10 @@ class PaymentCartFragment : Fragment() {
             getString(R.string.payment_cancelled),
             error ?: getString(R.string.payment_cancelled_message)
         )
+    }
+
+    private fun showPaymentInProgress() {
+        (activity as? PaymentCartActivity)?.setLoadingProgress(false)
     }
 
     companion object {

--- a/wechat/build.gradle
+++ b/wechat/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
+    testImplementation 'io.mockk:mockk:1.12.2'
 }
 
 ext {

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
@@ -70,8 +70,8 @@ class WeChatComponent : ActionComponent {
         this.listener = listener
         when (nextAction?.type) {
             NextAction.NextActionType.CALL_SDK -> {
-                val nextActionData = nextAction.data
-                if (nextActionData == null) {
+                val weChat = nextAction.getWechatData()
+                if (weChat == null) {
                     listener.onCompleted(
                         AirwallexPaymentStatus.Failure(
                             AirwallexCheckoutException(
@@ -81,15 +81,6 @@ class WeChatComponent : ActionComponent {
                     )
                     return
                 }
-                val weChat = WeChat(
-                    appId = nextActionData["appId"] as? String,
-                    partnerId = nextActionData["partnerId"] as? String,
-                    prepayId = nextActionData["prepayId"] as? String,
-                    `package` = nextActionData["package"] as? String,
-                    nonceStr = nextActionData["nonceStr"] as? String,
-                    timestamp = nextActionData["timeStamp"] as? String,
-                    sign = nextActionData["sign"] as? String
-                )
 
                 val prepayId = weChat.prepayId
 
@@ -114,6 +105,8 @@ class WeChatComponent : ActionComponent {
                                 AirwallexCheckoutException(message = "Failed to initialize WeChat app.")
                             )
                         )
+                    } else {
+                        listener.onCompleted(AirwallexPaymentStatus.InProgress(paymentIntentId))
                     }
                 }
             }
@@ -163,5 +156,19 @@ class WeChatComponent : ActionComponent {
         weChatReq.options.callbackClassName = WeChatPayAuthActivity::class.java.name
 
         return weChatReq
+    }
+
+    private fun NextAction.getWechatData(): WeChat? {
+        return data?.let {
+            WeChat(
+                appId = it["appId"] as? String,
+                partnerId = it["partnerId"] as? String,
+                prepayId = it["prepayId"] as? String,
+                `package` = it["package"] as? String,
+                nonceStr = it["nonceStr"] as? String,
+                timestamp = it["timeStamp"] as? String,
+                sign = it["sign"] as? String
+            )
+        }
     }
 }

--- a/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
+++ b/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
@@ -1,13 +1,94 @@
 package com.airwallex.wechat
 
+import android.app.Activity
+import android.content.Context
+import com.airwallex.android.core.Airwallex
+import com.airwallex.android.core.AirwallexPaymentStatus
+import com.airwallex.android.core.model.NextAction
+import com.airwallex.android.core.model.WeChat
 import com.airwallex.android.wechat.WeChatComponent
+import com.tencent.mm.opensdk.openapi.IWXAPI
+import com.tencent.mm.opensdk.openapi.WXAPIFactory
+import io.mockk.*
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertNotNull
 
 class WeChatComponentTest {
+    lateinit var component: WeChatComponent
+    lateinit var activity: Activity
+    lateinit var context: Context
+    lateinit var listener: Airwallex.PaymentResultListener
+    private val actionData = mapOf(
+        "appId" to "wx4c86d73fe4f82431",
+        "nonceStr" to "DUY8tIYUmyKO6Lhb1jTBFKUBWNud6XXu",
+        "package" to "Sign=WXPay",
+        "partnerId" to "403011682",
+        "prepayId" to "airwallex.com/pa/mock/wechat/hk/v2/qr_code_scanned",
+        "sign" to "EDD7AFB573F30F4C131898D631AA5ED3DA8FE92289536A6BE43426E71F2A2798",
+        "timeStamp" to "1629872988"
+    )
+
+    @Before
+    fun setUp() {
+        component = spyk(recordPrivateCalls = true)
+        activity = mockk()
+        context = mockk()
+        listener = mockk(relaxed = true)
+
+        val mockAPI = mockk<IWXAPI>()
+        mockkStatic(WXAPIFactory::class)
+        every { WXAPIFactory.createWXAPI(context, null, true) } returns mockAPI
+    }
+
+    @After
+    fun unmockStatics() {
+        unmockkStatic(WXAPIFactory::class)
+    }
 
     @Test
-    fun test() {
+    fun `test provider`() {
         assertNotNull(WeChatComponent.PROVIDER)
+    }
+
+    @Test
+    fun `test handlePaymentIntentResponse when WeChat Pay is successfully initiated`() {
+        every { component["initiateWeChatPay"](any<WeChat>()) } returns true
+        handlePaymentIntentResponse(actionData)
+
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.InProgress("id")) }
+    }
+
+    @Test
+    fun `test handlePaymentIntentResponse when next action data is null`() {
+        handlePaymentIntentResponse()
+
+        verify(exactly = 1) { listener.onCompleted(any()) }
+    }
+
+    @Test
+    fun `test handlePaymentIntentResponse when next action data is empty`() {
+        every { component["initiateWeChatPay"](any<WeChat>()) } returns true
+        handlePaymentIntentResponse(mapOf())
+
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.InProgress("id")) }
+    }
+
+    private fun handlePaymentIntentResponse(actionData: Map<String, Any?>? = null) {
+        component.handlePaymentIntentResponse(
+            paymentIntentId = "id",
+            nextAction = NextAction(
+                type = NextAction.NextActionType.CALL_SDK,
+                dcc = null,
+                url = null,
+                method = "post",
+                data = actionData
+            ),
+            activity = activity,
+            applicationContext = context,
+            cardNextActionModel = null,
+            listener = listener
+        )
     }
 }


### PR DESCRIPTION
This PR fixes the unstoppable loading when user comes back from Wechat during the payment by:
- Setting payment status as `In Progress` and notifying the merchant/sample app when Wechat is launched
- Sample/merchant app can have custom handler of dismissing the spinner or showing a confirm dialog to ask user if he finishes the payment 