### PR TITLE
[MOB-1097] Decode account id from client secret and provide to googlepay

### DIFF
--- a/GUIDE-zh.md
+++ b/GUIDE-zh.md
@@ -168,8 +168,7 @@ Airwallex Android SDK 支持Android API 19及以上版本。
                     countryCode = Settings.countryCode,
                     googlePayOptions = GooglePayOptions(
                         billingAddressRequired = true,
-                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
-                        merchantId = {PUBLIC_MERCHANT_ID}
+                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL)
                     )
                 )
                     .setReturnUrl(Settings.returnUrl)
@@ -244,12 +243,10 @@ Airwallex Android SDK 支持Android API 19及以上版本。
 Airwallex Android SDK可以通过以下步骤允许商户给顾客提供Google Pay作为支付方式：
 - 确认Google Pay在您的Airwallex账号上已开通
 - 根据[添加依赖](#添加依赖)在安装SDK时添加Google Pay模块
-- [创建付款资料](https://support.google.com/paymentscenter/answer/7161426?hl=zh-Hans)并获取[商户ID](https://support.google.com/googleplay/android-developer/answer/7163092?hl=zh-Hans)，然后用该ID去配置payment session object的`googlePayOptions`
 - 您可以自定义Google Pay选项来限制或提供额外的付款参数。请参考`GooglePayOptions`类中的更多信息。
 ```
 val googlePayOptions = GooglePayOptions(
         allowedCardAuthMethods = listOf("3DS"),
-        merchantId = {PUBLIC_MERCHANT_ID},
         billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
         shippingAddressParameters = ShippingAddressParameters(listOf("AU", "CN"), true)
     )

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -170,8 +170,7 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
                     countryCode = Settings.countryCode,
                     googlePayOptions = GooglePayOptions(
                         billingAddressRequired = true,
-                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
-                        merchantId = {PUBLIC_MERCHANT_ID}
+                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL)
                     )
                 )
                     .setReturnUrl(Settings.returnUrl)
@@ -247,12 +246,10 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
 The Airwallex Android SDK allows merchants to provide Google Pay as a payment method to their customers by the following steps:
 - Make sure Google Pay is enabled on your Airwallex account.
 - Include the Google Pay module when installing the SDK as per [Step1](#step1-set-up-sdk).
-- [Create a payments profile](https://support.google.com/paymentscenter/answer/7161426) and get the [Merchant ID](https://support.google.com/googleplay/android-developer/answer/7163092), and use it to configure `googlePayOptions` on the payment session object. 
 - You can customize the Google Pay options to restrict as well as provide extra context. For more information, please refer to `GooglePayOptions` class.
 ```
 val googlePayOptions = GooglePayOptions(
         allowedCardAuthMethods = listOf("3DS"),
-        merchantId = {PUBLIC_MERCHANT_ID},
         billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
         shippingAddressParameters = ShippingAddressParameters(listOf("AU", "CN"), true)
     )

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPlugins.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPlugins.kt
@@ -35,13 +35,14 @@ object AirwallexPlugins {
 
     @Suppress("SwallowedException")
     fun getProvider(paymentMethodType: AvailablePaymentMethodType): ActionComponentProvider<out ActionComponent>? {
-        if (paymentMethodType.resources?.hasSchema == true) {
-            return getProvider(ActionComponentProviderType.REDIRECT)
-        }
-        return try {
+        return runCatching {
             getProvider(ActionComponentProviderType.valueOf(paymentMethodType.name.uppercase()))
-        } catch (e: IllegalArgumentException) {
-            null
+        }.getOrElse {
+            if (paymentMethodType.resources?.hasSchema == true) {
+                getProvider(ActionComponentProviderType.REDIRECT)
+            } else {
+                null
+            }
         }
     }
 

--- a/components-core/src/main/java/com/airwallex/android/core/GooglePayOptions.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/GooglePayOptions.kt
@@ -11,10 +11,6 @@ data class GooglePayOptions(
      */
     val allowedCardAuthMethods: List<String>? = null,
     /**
-     * Google Pay merchant identifier
-     */
-    val merchantId: String,
-    /**
      * Merchant name encoded as UTF-8.
      */
     val merchantName: String? = null,

--- a/components-core/src/main/java/com/airwallex/android/core/TokenManager.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/TokenManager.kt
@@ -1,0 +1,28 @@
+package com.airwallex.android.core
+
+import android.util.Base64
+import org.json.JSONObject
+
+object TokenManager {
+    private var clientSecret: String? = null
+    var accountId: String? = null
+
+    fun updateClientSecret(clientSecret: String) {
+        if (clientSecret != this.clientSecret) {
+            this.clientSecret = clientSecret
+            val body = clientSecret.split(".").getOrNull(1)
+            if (body != null) {
+                runCatching {
+                    accountId = JSONObject(
+                        String(
+                            Base64.decode(
+                                body,
+                                Base64.DEFAULT
+                            )
+                        )
+                    ).getString("account_id")
+                }
+            }
+        }
+    }
+}

--- a/components-core/src/test/java/com/airwallex/android/core/TokenManagerTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/TokenManagerTest.kt
@@ -1,0 +1,23 @@
+package com.airwallex.android.core
+
+import android.util.Base64
+import io.mockk.every
+import io.mockk.mockkStatic
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TokenManagerTest {
+    @Test
+    fun `test accountId when update client secret`() {
+        val payload = """
+            {
+              "type":"client-secret",
+              "account_id": "edaf126c-f600-4653-95ea-4680b60fcce5"
+            }
+        """.trimIndent()
+        mockkStatic(Base64::class)
+        every { Base64.decode("def", Base64.DEFAULT) } returns payload.toByteArray()
+        TokenManager.updateClientSecret("abc.def.gh")
+        assertEquals(TokenManager.accountId, "edaf126c-f600-4653-95ea-4680b60fcce5")
+    }
+}

--- a/components-core/src/test/java/com/airwallex/android/core/model/GooglePayOptionsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/GooglePayOptionsTest.kt
@@ -11,7 +11,6 @@ class GooglePayOptionsTest {
     private val googlePayOptions by lazy {
         GooglePayOptions(
             allowedCardAuthMethods = listOf("3DS"),
-            merchantId = "id",
             billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
             shippingAddressParameters = ShippingAddressParameters(listOf("AU", "CN"), true)
         )
@@ -20,7 +19,6 @@ class GooglePayOptionsTest {
     @Test
     fun testParams() {
         assertEquals(googlePayOptions.allowedCardAuthMethods?.first(), "3DS")
-        assertEquals(googlePayOptions.merchantId, "id")
         assertNull(googlePayOptions.allowCreditCards)
         assertNull(googlePayOptions.allowPrepaidCards)
         assertNull(googlePayOptions.assuranceDetailsRequired)

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.googlepay
 import android.app.Activity
 import com.airwallex.android.core.AirwallexPlugins
 import com.airwallex.android.core.GooglePayOptions
+import com.airwallex.android.core.TokenManager
 import com.airwallex.android.core.model.Address
 import com.airwallex.android.core.model.Billing
 import com.airwallex.android.core.model.CardScheme
@@ -41,7 +42,7 @@ object PaymentsUtil {
      * @throws JSONException
      * @see [PaymentMethodTokenizationSpecification](https://developers.google.com/pay/api/android/reference/object.PaymentMethodTokenizationSpecification)
      */
-    private fun gatewayTokenizationSpecification(merchantId: String): JSONObject {
+    private fun gatewayTokenizationSpecification(): JSONObject {
         return JSONObject().apply {
             put("type", "PAYMENT_GATEWAY")
             put(
@@ -49,7 +50,7 @@ object PaymentsUtil {
                 JSONObject(
                     mapOf(
                         "gateway" to Constants.PAYMENT_GATEWAY_TOKENIZATION_NAME,
-                        "gatewayMerchantId" to merchantId
+                        "gatewayMerchantId" to (TokenManager.accountId ?: "")
                     )
                 )
             )
@@ -130,7 +131,7 @@ object PaymentsUtil {
         val cardPaymentMethod = baseCardPaymentMethod(googlePayOptions, cardList)
         cardPaymentMethod.put(
             "tokenizationSpecification",
-            gatewayTokenizationSpecification(googlePayOptions.merchantId)
+            gatewayTokenizationSpecification()
         )
 
         return cardPaymentMethod

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentProviderTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentProviderTest.kt
@@ -37,7 +37,7 @@ class GooglePayComponentProviderTest {
             currency = "AUD"
         ),
         "AU",
-        GooglePayOptions(merchantId = "merchantId")
+        GooglePayOptions()
     ).build()
 
     private val componentProvider: GooglePayComponentProvider by lazy {

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
@@ -20,7 +20,7 @@ class PaymentsUtilTest {
     @Test
     fun `test isReadyToPayRequest without supported card schemes`() {
         val request = PaymentsUtil.isReadyToPayRequest(
-            GooglePayOptions(merchantId = "merchantId"), null
+            GooglePayOptions(), null
         )
         assertEquals(
             request.toString(),
@@ -33,7 +33,7 @@ class PaymentsUtilTest {
     @Test
     fun `test isReadyToPayRequest with supported card schemes`() {
         val request = PaymentsUtil.isReadyToPayRequest(
-            GooglePayOptions(merchantId = "merchantId"),
+            GooglePayOptions(),
             listOf(CardScheme("mastercard"))
         )
         assertEquals(
@@ -48,7 +48,6 @@ class PaymentsUtilTest {
     fun `test isReadyToPayRequest with billing address params and other requirements`() {
         val request = PaymentsUtil.isReadyToPayRequest(
             GooglePayOptions(
-                merchantId = "merchantId",
                 allowPrepaidCards = false,
                 allowCreditCards = false,
                 assuranceDetailsRequired = true,
@@ -77,7 +76,6 @@ class PaymentsUtilTest {
             countryCode = "AU",
             currency = "AUD",
             googlePayOptions = GooglePayOptions(
-                merchantId = "merchantId",
                 merchantName = "Some Merchant",
                 transactionId = "zcvrwf14r1",
                 checkoutOption = "COMPLETE_IMMEDIATE_PURCHASE",
@@ -95,7 +93,7 @@ class PaymentsUtilTest {
                     "\"Some Merchant\"},\"allowedPaymentMethods\":[{\"type\":\"CARD\",\"parameters\":" +
                     "{\"allowedAuthMethods\":[\"PAN_ONLY\",\"CRYPTOGRAM_3DS\"],\"allowedCardNetworks\":" +
                     "[\"MASTERCARD\",\"VISA\"]},\"tokenizationSpecification\":{\"type\":\"PAYMENT_GATEWAY\"," +
-                    "\"parameters\":{\"gatewayMerchantId\":\"merchantId\",\"gateway\":\"airwallex\"}}}]," +
+                    "\"parameters\":{\"gatewayMerchantId\":\"\",\"gateway\":\"airwallex\"}}}]," +
                     "\"shippingAddressParameters\":{\"allowedCountryCodes\":[\"US\",\"CN\"]," +
                     "\"phoneNumberRequired\":true},\"emailRequired\":true,\"transactionInfo\":" +
                     "{\"totalPrice\":\"100.01\",\"countryCode\":\"AU\",\"totalPriceLabel\":\"order.total\"," +

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,5 @@ org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M
 
 AIRWALLEX_API_KEY="put your api key here"
 AIRWALLEX_CLIENT_ID="put your client id here"
-AIRWALLEX_ACCOUNT_ID="put your account id here"
 AIRWALLEX_WECHAT_APP_ID="put your WeChat app id here"
 AIRWALLEX_RETURN_URL=airwallexcheckout://com.airwallex.paymentacceptance

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,10 +17,6 @@ def getClientId() {
     return readProperty('AIRWALLEX_CLIENT_ID')
 }
 
-def getAccountId() {
-    return readProperty('AIRWALLEX_ACCOUNT_ID')
-}
-
 def getWeChatAppId() {
     return readProperty('AIRWALLEX_WECHAT_APP_ID')
 }
@@ -62,7 +58,6 @@ android {
         manifestPlaceholders = [
                 AIRWALLEX_API_KEY             : getApiKey(),
                 AIRWALLEX_CLIENT_ID           : getClientId(),
-                AIRWALLEX_ACCOUNT_ID          : getAccountId(),
                 AIRWALLEX_WECHAT_APP_ID       : getWeChatAppId(),
                 AIRWALLEX_RETURN_URL          : getReturnUrl()
         ]

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
             android:name="com.airwallex.sample.metadata.client_id"
             android:value="${AIRWALLEX_CLIENT_ID}" />
         <meta-data
-            android:name="com.airwallex.sample.metadata.account_id"
-            android:value="${AIRWALLEX_ACCOUNT_ID}" />
-        <meta-data
             android:name="com.airwallex.sample.metadata.wechat_app_id"
             android:value="${AIRWALLEX_WECHAT_APP_ID}" />
         <meta-data

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -156,8 +156,7 @@ class PaymentCartFragment : Fragment() {
                     countryCode = Settings.countryCode,
                     googlePayOptions = GooglePayOptions(
                         billingAddressRequired = true,
-                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
-                        merchantId = "423102959764541877"
+                        billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL)
                     )
                 )
                     .setReturnUrl(Settings.returnUrl)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
@@ -200,7 +200,6 @@ class PaymentSettingsFragment :
 
         onSharedPreferenceChanged(preferences, getString(R.string.api_key))
         onSharedPreferenceChanged(preferences, getString(R.string.client_id))
-        onSharedPreferenceChanged(preferences, getString(R.string.account_id))
         onSharedPreferenceChanged(preferences, getString(R.string.price))
         onSharedPreferenceChanged(preferences, getString(R.string.currency))
         onSharedPreferenceChanged(preferences, getString(R.string.country_code))
@@ -233,7 +232,6 @@ class PaymentSettingsFragment :
         when (key) {
             getString(R.string.api_key) -> preference?.summary = Settings.apiKey
             getString(R.string.client_id) -> preference?.summary = Settings.clientId
-            getString(R.string.account_id) -> preference?.summary = Settings.accountId
             getString(R.string.price) -> {
                 preference?.summary = Settings.price
                 (preference as EditTextPreference).setOnBindEditTextListener { editText ->

--- a/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
@@ -13,9 +13,6 @@ object Settings {
     // Client Id
     private const val CLIENT_ID = ""
 
-    // Account Id
-    private const val ACCOUNT_ID = ""
-
     // WeChat Pay App Id
     private const val WECHAT_APP_ID = ""
 
@@ -27,7 +24,6 @@ object Settings {
 
     private const val METADATA_KEY_API_KEY = "com.airwallex.sample.metadata.api_key"
     private const val METADATA_KEY_CLIENT_ID_KEY = "com.airwallex.sample.metadata.client_id"
-    private const val METADATA_KEY_ACCOUNT_ID_KEY = "com.airwallex.sample.metadata.account_id"
     private const val METADATA_KEY_WECHAT_APP_ID_KEY = "com.airwallex.sample.metadata.wechat_app_id"
     private const val METADATA_KEY_RETURN_URL = "com.airwallex.sample.metadata.return_url"
 
@@ -127,12 +123,6 @@ object Settings {
         get() {
             return sharedPreferences.getString(context.getString(R.string.client_id), getMetadata(METADATA_KEY_CLIENT_ID_KEY))
                 ?: CLIENT_ID
-        }
-
-    val accountId: String
-        get() {
-            return sharedPreferences.getString(context.getString(R.string.account_id), getMetadata(METADATA_KEY_ACCOUNT_ID_KEY))
-                ?: ACCOUNT_ID
         }
 
     val weChatAppId: String

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="wechat">WeChat</string>
     <string name="api_key">API Key</string>
     <string name="client_id">Client ID</string>
-    <string name="account_id">Account ID</string>
     <string name="wechat_app_id">App ID</string>
 
     <string name="app_name">Airwallex Sample</string>

--- a/sample/src/main/res/xml/settings.xml
+++ b/sample/src/main/res/xml/settings.xml
@@ -66,10 +66,6 @@
             android:key="@string/client_id"
             android:title="@string/client_id" />
 
-        <EditTextPreference
-            android:key="@string/account_id"
-            android:title="@string/account_id"/>
-
     </PreferenceCategory>
 
 


### PR DESCRIPTION
This PR saves the need for the user to offer merchant ID to Google Pay by:

- Decode account ID from the client secret
- Make fallback value empty string if not being able to decode (doesn't affect payment, and aligns with web)
- Remove account ID input from settings in demo