### PR TITLE
[MOB-1123] Filter payment methods

### DIFF
--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -168,7 +168,6 @@ class Airwallex internal constructor(
         )
         val filteredItems = response.items?.filter { paymentMethod ->
             paymentMethod.transactionMode == transactionMode &&
-                    paymentMethod.name !in unsupportedPaymentMethodTypes &&
                     AirwallexPlugins.getProvider(paymentMethod)?.let { provider ->
                         provider.canHandleSessionAndPaymentMethod(
                             session,
@@ -1039,13 +1038,6 @@ class Airwallex internal constructor(
 
     companion object {
         const val AIRWALLEX_CHECKOUT_SCHEMA = "airwallexcheckout"
-        private val unsupportedPaymentMethodTypes = listOf(
-            "applepay",
-            "ach_direct_debit", // todo: remove once mandate is rendered properly
-            "becs_direct_debit", // todo: remove once mandate is rendered properly
-            "sepa_direct_debit", // todo: remove once mandate is rendered properly
-            "bacs_direct_debit" // todo: remove once mandate is rendered properly
-        )
 
         /**
          * Initialize some global configurations, better to be called on Application

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
@@ -11,7 +11,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class AirwallexPluginsTest {
-    private class TestComponentProvider(val providerType: ActionComponentProviderType) : ActionComponentProvider<TestComponnent> {
+    private class TestComponentProvider(val providerType: ActionComponentProviderType) :
+        ActionComponentProvider<TestComponnent> {
         override fun get(): TestComponnent {
             return TestComponnent()
         }
@@ -88,7 +89,7 @@ class AirwallexPluginsTest {
     }
 
     @Test
-    fun `test get redirect action component provider`() {
+    fun `test get redirect action component provider when hasSchema is true`() {
         AirwallexPlugins.initialize(
             AirwallexConfiguration.Builder()
                 .setSupportComponentProviders(
@@ -110,7 +111,28 @@ class AirwallexPluginsTest {
     }
 
     @Test
-    fun `test can't get action component provider`() {
+    fun `test get redirect action component provider when hasSchema is false`() {
+        AirwallexPlugins.initialize(
+            AirwallexConfiguration.Builder()
+                .setSupportComponentProviders(
+                    listOf(
+                        TestComponentProvider(ActionComponentProviderType.REDIRECT)
+                    )
+                )
+                .build()
+        )
+        assertNull(
+            AirwallexPlugins.getProvider(
+                AvailablePaymentMethodType(
+                    name = "alipaycn",
+                    resources = AvailablePaymentMethodTypeResource(false)
+                )
+            )?.getType()
+        )
+    }
+
+    @Test
+    fun `test can't get action component provider when no providers are registered`() {
         val provider = AirwallexPlugins.getProvider(
             AvailablePaymentMethodType(
                 "card"


### PR DESCRIPTION
Since the `hasSchema=true` filter logic already exists in [code](https://github.com/airwallex/airwallex-payment-android/blob/bbf0ffba4bf3a1ad14b5b5b2b0b62dea355a4083/components-core/src/main/java/com/airwallex/android/core/AirwallexPlugins.kt#L41), this Pr just:

- Removes unnecessary hardcoding since the only check needs to do with is `hasSchema` after checking with PA.