### PR TITLE
[MOB-1120] Add amex card number format and fix saved card logo

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/CardBrand.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/CardBrand.kt
@@ -9,7 +9,9 @@ import com.airwallex.android.R
 enum class CardBrand(
     val type: String,
     @DrawableRes val icon: Int,
-    private val prefixes: Set<String> = emptySet()
+    private val prefixes: Set<String> = emptySet(),
+    private val fullName: String = type,
+    val spacingPattern: List<Int> = listOf(4, 4, 4, 4)
 ) {
     Visa(
         "visa",
@@ -28,7 +30,9 @@ enum class CardBrand(
     Amex(
         "amex",
         R.drawable.airwallex_ic_amex,
-        prefixes = setOf("34", "37")
+        prefixes = setOf("34", "37"),
+        fullName = "american express",
+        spacingPattern = listOf(4, 6, 5)
     ),
     Unknown(
         "unknown",
@@ -52,7 +56,7 @@ enum class CardBrand(
             } ?: Unknown
         }
 
-        private val map = values().associateBy(CardBrand::type)
-        fun fromType(type: String) = map[type]
+        fun fromType(type: String) = values().associateBy(CardBrand::type)[type]
+        fun fromName(name: String) = values().associateBy(CardBrand::fullName)[name]
     }
 }

--- a/airwallex/src/main/java/com/airwallex/android/view/CardUtils.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/CardUtils.kt
@@ -101,4 +101,23 @@ object CardUtils {
             .takeUnless { it.isNullOrBlank() }
             ?.replace("\\s|-".toRegex(), "")
     }
+
+    /**
+     * Get space position by spacing pattern of the card brand
+     * e.g. spacing pattern 4-4-4-4 is correlated to space position 4-9-14
+     */
+    fun getSpacePositions(cardBrand: CardBrand): Set<Int> {
+        val spacePostions = mutableSetOf<Int>()
+        var spaceIndex = 0
+        var lastPosition = 0
+        while (spaceIndex < cardBrand.spacingPattern.size - 1) {
+            lastPosition += cardBrand.spacingPattern[spaceIndex]
+            if (spaceIndex > 0) {
+                lastPosition++
+            }
+            spacePostions.add(lastPosition)
+            spaceIndex++
+        }
+        return spacePostions
+    }
 }

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsAdapter.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsAdapter.kt
@@ -118,7 +118,7 @@ internal class PaymentMethodsAdapter(
                 )
 
             val cardBrand = card.brand?.let {
-                CardBrand.fromType(it)
+                CardBrand.fromName(it)
             }
             if (cardBrand != null) {
                 viewBinding.ivCardIcon.setImageResource(cardBrand.icon)

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsAdapter.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsAdapter.kt
@@ -172,6 +172,7 @@ internal class PaymentMethodsAdapter(
             Glide.with(viewBinding.root.context)
                 .load(paymentMethodType.resources?.logos?.png)
                 .error(if (paymentMethodType.name == PaymentMethodType.CARD.value) R.drawable.airwallex_ic_card_default else 0)
+                .fitCenter()
                 .into(viewBinding.paymentMethodIcon)
             itemView.setOnSingleClickListener {
                 if (paymentMethodType.name == PaymentMethodType.CARD.value) {

--- a/airwallex/src/test/java/com/airwallex/android/view/CardBrandTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardBrandTest.kt
@@ -10,19 +10,29 @@ class CardBrandTest {
     fun `test card brands`() {
         assertEquals("visa", CardBrand.Visa.type)
         assertEquals(R.drawable.airwallex_ic_visa, CardBrand.Visa.icon)
+        assertEquals(listOf(4, 4, 4, 4), CardBrand.Visa.spacingPattern)
 
         assertEquals("mastercard", CardBrand.MasterCard.type)
         assertEquals(R.drawable.airwallex_ic_mastercard, CardBrand.MasterCard.icon)
+        assertEquals(listOf(4, 4, 4, 4), CardBrand.MasterCard.spacingPattern)
 
         assertEquals("amex", CardBrand.Amex.type)
         assertEquals(R.drawable.airwallex_ic_amex, CardBrand.Amex.icon)
+        assertEquals(listOf(4, 6, 5), CardBrand.Amex.spacingPattern)
 
         assertEquals("unknown", CardBrand.Unknown.type)
         assertEquals(R.drawable.airwallex_ic_card_default, CardBrand.Unknown.icon)
+        assertEquals(listOf(4, 4, 4, 4), CardBrand.Unknown.spacingPattern)
     }
 
     @Test
     fun `test fromType`() {
         assertEquals(CardBrand.fromType("mastercard"), CardBrand.MasterCard)
+    }
+
+    @Test
+    fun `test fromName`() {
+        assertEquals(CardBrand.fromName("mastercard"), CardBrand.MasterCard)
+        assertEquals(CardBrand.fromName("american express"), CardBrand.Amex)
     }
 }

--- a/airwallex/src/test/java/com/airwallex/android/view/CardNumberEditTextTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardNumberEditTextTest.kt
@@ -67,4 +67,16 @@ class CardNumberEditTextTest {
         assertNull(error)
         assertEquals(cardBrand, CardBrand.Visa)
     }
+
+    @Test
+    fun `test amex card number auto formatt`() {
+        cardNumberEditText.setText("378282246310005")
+        assertEquals(cardNumberEditText.text.toString(), "3782 822463 10005")
+    }
+
+    @Test
+    fun `test visa card number auto format`() {
+        cardNumberEditText.setText("4242424242424244")
+        assertEquals(cardNumberEditText.text.toString(), "4242 4242 4242 4244")
+    }
 }

--- a/airwallex/src/test/java/com/airwallex/android/view/CardUtilsTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardUtilsTest.kt
@@ -39,4 +39,10 @@ class CardUtilsTest {
         assertFalse(CardUtils.isValidLuhnNumber("4242424242424244"))
         assertFalse(CardUtils.isValidLuhnNumber(null))
     }
+
+    @Test
+    fun `test getSpacePositions`() {
+        assertEquals(CardUtils.getSpacePositions(CardBrand.MasterCard), setOf(4, 9, 14))
+        assertEquals(CardUtils.getSpacePositions(CardBrand.Amex), setOf(4, 11))
+    }
 }


### PR DESCRIPTION
This pr adds:
-  Amex specific card spacing pattern

And fixes:
- Amex logo isn't shown due to the payment consent response uses full name (i.e. `american express`) which is different from payment methods config response.

<img width="200" alt="Screen Shot 2022-11-14 at 17 59 59" src="https://user-images.githubusercontent.com/107159278/201631380-1757d7d9-905b-424a-b716-d9c19ab1094c.png">

<img width="200" alt="Screen Shot 2022-11-14 at 18 02 29" src="https://user-images.githubusercontent.com/107159278/201631953-1bd81c21-c184-4e2a-bd6b-4cd768e9ca81.png">

<img width="200" alt="Screen Shot 2022-11-14 at 18 00 16" src="https://user-images.githubusercontent.com/107159278/201631444-19af7c75-0524-4289-ac32-dbf2d8c77686.png">