### PR TITLE
fix: fixed an issue where maven GPG private key is not passed in correctly

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
       # Packages and publishes to Maven Central
       - name: Publish to Maven Central
         run: |
-          ./gradlew \
+          ./gradlew --stacktrace \
           publishReleasePublicationToSonatypeRepository --max-workers 1 \
           closeAndReleaseSonatypeStagingRepository
         env:
@@ -37,5 +37,6 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_BASE64 }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           AIRWALLEX_VERSION_CODE: ${{ github.run_number }}

--- a/gradle/scripts/publish-root.gradle
+++ b/gradle/scripts/publish-root.gradle
@@ -13,10 +13,27 @@ if (secretPropsFile.exists()) {
     }
 } else {
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-    ext["signing.key"] = System.getenv('SIGNING_KEY')
+
+    String decoded = decodeBase64Key(System.getenv('SIGNING_KEY_BASE64'))
+    if (decoded != null) {
+        ext["signing.key"] = decoded
+    } else {
+        ext["signing.key"] = System.getenv('SIGNING_KEY')
+    }
+
     ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
     ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+}
+
+static def decodeBase64Key(encodedString) {
+    if (encodedString != null) {
+        byte[] decoded = encodedString.decodeBase64()
+        String decode = new String(decoded)
+        return decode
+    } else {
+        return null
+    }
 }
 
 nexusPublishing {


### PR DESCRIPTION
This PR fixed an issue where signing the maven publications will fail due to unescaped characters by encoding the key using base64 first. So the sequence becomes:
- get the key on the password manager
- encode the signing key using base64
- assign it to the SIGNING_KEY_BASE64 GitHub actions secret.
- decode the key in gradle.
- pass the decoded key to the signing method.