### PR TITLE
[MOB-1378] Add cvcRequired to google pay request and rectify analytics

### DIFF
--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponentProvider.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import com.airwallex.android.core.ActionComponentProvider
 import com.airwallex.android.core.ActionComponentProviderType
 import com.airwallex.android.core.AirwallexSession
-import com.airwallex.android.core.exception.AirwallexException
+import com.airwallex.android.core.extension.putIfNotNull
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.ConsoleLogger
 import com.airwallex.android.core.model.AvailablePaymentMethodType
@@ -67,12 +67,9 @@ class GooglePayComponentProvider : ActionComponentProvider<GooglePayComponent> {
                     // Process error
                     AnalyticsLogger.logError(
                         "googlepay_is_ready",
-                        exception = object : AirwallexException(
-                            null,
-                            null,
-                            exception.statusCode,
-                            exception.message
-                        ) {}
+                        mutableMapOf<String, Any>("code" to exception.statusCode).apply {
+                            putIfNotNull("message", exception.message)
+                        }
                     )
                     ConsoleLogger.error("isReadyToPay failed", exception)
                     cont.resume(false)

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/PaymentsUtil.kt
@@ -110,6 +110,7 @@ object PaymentsUtil {
                         }
                     )
                 }
+                put("cvcRequired", true)
             }
 
             put("type", "CARD")

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/PaymentsUtilTest.kt
@@ -25,7 +25,7 @@ class PaymentsUtilTest {
         assertEquals(
             request.toString(),
             "{\"apiVersionMinor\":0,\"apiVersion\":2,\"allowedPaymentMethods\":" +
-                    "[{\"type\":\"CARD\",\"parameters\":{\"allowedAuthMethods\":[\"PAN_ONLY\"," +
+                    "[{\"type\":\"CARD\",\"parameters\":{\"cvcRequired\":true,\"allowedAuthMethods\":[\"PAN_ONLY\"," +
                     "\"CRYPTOGRAM_3DS\"],\"allowedCardNetworks\":[\"MASTERCARD\",\"VISA\"]}}]}"
         )
     }
@@ -39,7 +39,7 @@ class PaymentsUtilTest {
         assertEquals(
             request.toString(),
             "{\"apiVersionMinor\":0,\"apiVersion\":2,\"allowedPaymentMethods\":" +
-                    "[{\"type\":\"CARD\",\"parameters\":{\"allowedAuthMethods\":[\"PAN_ONLY\"," +
+                    "[{\"type\":\"CARD\",\"parameters\":{\"cvcRequired\":true,\"allowedAuthMethods\":[\"PAN_ONLY\"," +
                     "\"CRYPTOGRAM_3DS\"],\"allowedCardNetworks\":[\"MASTERCARD\"]}}]}"
         )
     }
@@ -61,7 +61,7 @@ class PaymentsUtilTest {
         assertEquals(
             request.toString(),
             "{\"apiVersionMinor\":0,\"apiVersion\":2,\"allowedPaymentMethods\":" +
-                    "[{\"type\":\"CARD\",\"parameters\":{\"assuranceDetailsRequired\":true," +
+                    "[{\"type\":\"CARD\",\"parameters\":{\"cvcRequired\":true,\"assuranceDetailsRequired\":true," +
                     "\"allowedAuthMethods\":[\"PAN_ONLY\",\"CRYPTOGRAM_3DS\"],\"billingAddressRequired\":true," +
                     "\"billingAddressParameters\":{\"format\":\"FULL\",\"phoneNumberRequired\":true}," +
                     "\"allowedCardNetworks\":[\"MASTERCARD\",\"VISA\"],\"allowCreditCards\":false," +
@@ -89,9 +89,9 @@ class PaymentsUtilTest {
         )
         assertEquals(
             request.toString(),
-            "{\"apiVersionMinor\":0,\"apiVersion\":2,\"merchantInfo\":{\"merchantName\":" +
-                    "\"Some Merchant\"},\"allowedPaymentMethods\":[{\"type\":\"CARD\",\"parameters\":" +
-                    "{\"allowedAuthMethods\":[\"PAN_ONLY\",\"CRYPTOGRAM_3DS\"],\"allowedCardNetworks\":" +
+            "{\"apiVersionMinor\":0,\"apiVersion\":2,\"merchantInfo\":{\"merchantName\":\"Some Merchant\"}," +
+                    "\"allowedPaymentMethods\":[{\"type\":\"CARD\",\"parameters\":{\"cvcRequired\":true," +
+                    "\"allowedAuthMethods\":[\"PAN_ONLY\",\"CRYPTOGRAM_3DS\"],\"allowedCardNetworks\":" +
                     "[\"MASTERCARD\",\"VISA\"]},\"tokenizationSpecification\":{\"type\":\"PAYMENT_GATEWAY\"," +
                     "\"parameters\":{\"gatewayMerchantId\":\"\",\"gateway\":\"airwallex\"}}}]," +
                     "\"shippingAddressParameters\":{\"allowedCountryCodes\":[\"US\",\"CN\"]," +


### PR DESCRIPTION
So that Google Pay shows cvc input field as follows:
<img src="https://github.com/airwallex/airwallex-payment-android/assets/107159278/748af855-23da-4ad1-8007-ede316e6a390" width=200/>
