### PR TITLE
[MOB-1862] Support passing multiple wechat payment states to PaymentResultListener

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/AirwallexStarter.kt
+++ b/airwallex/src/main/java/com/airwallex/android/AirwallexStarter.kt
@@ -117,6 +117,7 @@ class AirwallexStarter {
             paymentResultListener: Airwallex.PaymentResultListener
         ) {
             this.paymentResultListener = paymentResultListener
+            PaymentResultManager.getInstance(paymentResultListener)
             launch.startForResult(
                 PaymentMethodsActivityLaunch.Args.Builder()
                     .setAirwallexSession(session)

--- a/airwallex/src/test/java/com/airwallex/android/view/CardExpiryEditTextTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/CardExpiryEditTextTest.kt
@@ -77,7 +77,7 @@ class CardExpiryEditTextTest {
 
     @Test
     fun testValidDateFields() {
-        cardExpiryEditText.setText("12/23")
-        assertEquals(cardExpiryEditText.validDateFields, Pair(12, 2023))
+        cardExpiryEditText.setText("12/30")
+        assertEquals(cardExpiryEditText.validDateFields, Pair(12, 2030))
     }
 }

--- a/components-core/src/main/java/com/airwallex/android/core/PaymentResultManager.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/PaymentResultManager.kt
@@ -1,0 +1,22 @@
+package com.airwallex.android.core
+
+class PaymentResultManager private constructor(private val listener: Airwallex.PaymentResultListener) {
+    companion object {
+        @Volatile
+        private var instance: PaymentResultManager? = null
+
+        fun getInstance(
+            listener: Airwallex.PaymentResultListener = object : Airwallex.PaymentResultListener {
+                override fun onCompleted(status: AirwallexPaymentStatus) {
+                    // no op
+                }
+            }
+        ) = instance ?: synchronized(this) {
+                instance ?: PaymentResultManager(listener).also { instance = it }
+            }
+    }
+
+    fun completePayment(status: AirwallexPaymentStatus) {
+        listener.onCompleted(status)
+    }
+}

--- a/components-core/src/main/java/com/airwallex/android/core/model/WeChat.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/model/WeChat.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
  * WeChat Pay Payments
  */
 @Parcelize
-data class WeChat constructor(
+data class WeChat(
     val appId: String?,
     val partnerId: String?,
     val prepayId: String?,

--- a/components-core/src/test/java/com/airwallex/android/core/PaymentResultManagerTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/PaymentResultManagerTest.kt
@@ -1,0 +1,16 @@
+package com.airwallex.android.core
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class PaymentResultManagerTest {
+    @Test
+    fun `test complete payment`() {
+        val listener = mockk<Airwallex.PaymentResultListener>(relaxed = true)
+        val manager = PaymentResultManager.getInstance(listener)
+        val status = AirwallexPaymentStatus.InProgress("id")
+        manager.completePayment(status)
+        verify { listener.onCompleted(status) }
+    }
+}

--- a/wechat/src/main/AndroidManifest.xml
+++ b/wechat/src/main/AndroidManifest.xml
@@ -8,12 +8,10 @@
     </queries>
 
     <application>
-        <!--singleTop launchMode is required to capture callback from WeChat SDK
-        through Activity#onNewIntent-->
         <activity
             android:name=".WeChatPayAuthActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait" />
     </application>
 </manifest>

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatPayAuthActivity.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatPayAuthActivity.kt
@@ -2,6 +2,7 @@ package com.airwallex.android.wechat
 
 import android.app.Activity
 import android.os.Bundle
+import com.airwallex.android.core.PaymentResultManager
 
 internal class WeChatPayAuthActivity : Activity() {
 
@@ -12,7 +13,10 @@ internal class WeChatPayAuthActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         intent?.let {
-            weChatComponent.handleIntent(intent) {
+            weChatComponent.handleIntent(
+                intent = intent
+            ) { status ->
+                PaymentResultManager.getInstance().completePayment(status)
                 finish()
             }
         }

--- a/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
+++ b/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
@@ -2,25 +2,34 @@ package com.airwallex.wechat
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.model.NextAction
 import com.airwallex.android.core.model.WeChat
 import com.airwallex.android.wechat.WeChatComponent
+import com.tencent.mm.opensdk.modelbase.BaseResp
+import com.tencent.mm.opensdk.modelpay.PayResp
 import com.tencent.mm.opensdk.openapi.IWXAPI
+import com.tencent.mm.opensdk.openapi.IWXAPIEventHandler
 import com.tencent.mm.opensdk.openapi.WXAPIFactory
 import io.mockk.*
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 class WeChatComponentTest {
+    lateinit var wechatAPI: IWXAPI
     lateinit var component: WeChatComponent
     lateinit var activity: Activity
     lateinit var context: Context
+    lateinit var intent: Intent
     lateinit var listener: Airwallex.PaymentResultListener
+    lateinit var paymentCompletionHandler: (AirwallexPaymentStatus) -> Unit
     private val actionData = mapOf(
         "appId" to "wx4c86d73fe4f82431",
         "nonceStr" to "DUY8tIYUmyKO6Lhb1jTBFKUBWNud6XXu",
@@ -36,11 +45,13 @@ class WeChatComponentTest {
         component = spyk(recordPrivateCalls = true)
         activity = mockk()
         context = mockk()
+        intent = mockk()
         listener = mockk(relaxed = true)
+        paymentCompletionHandler = mockk(relaxed = true)
 
-        val mockAPI = mockk<IWXAPI>()
+        wechatAPI = mockk<IWXAPI>(relaxed = true)
         mockkStatic(WXAPIFactory::class)
-        every { WXAPIFactory.createWXAPI(context, null, true) } returns mockAPI
+        every { WXAPIFactory.createWXAPI(context, null, true) } returns wechatAPI
         mockkObject(AnalyticsLogger)
     }
 
@@ -89,6 +100,64 @@ class WeChatComponentTest {
         handlePaymentIntentResponse(mapOf())
 
         verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.InProgress("id")) }
+    }
+
+    @Test
+    fun `test handleIntent when WeChat response is ok`() {
+        val eventHandler = slot<IWXAPIEventHandler>()
+        val response = PayResp()
+        response.errCode = BaseResp.ErrCode.ERR_OK
+        every { wechatAPI.handleIntent(any(), capture(eventHandler)) } answers {
+            eventHandler.captured.onResp(response)
+            true
+        }
+
+        handlePaymentIntentResponse(actionData)
+        component.handleIntent(intent, paymentCompletionHandler)
+        verify(exactly = 1) { paymentCompletionHandler(AirwallexPaymentStatus.Success("id")) }
+    }
+
+    @Test
+    fun `test handleIntent when WeChat response is user cancel`() {
+        val eventHandler = slot<IWXAPIEventHandler>()
+        val response = PayResp()
+        response.errCode = BaseResp.ErrCode.ERR_USER_CANCEL
+        every { wechatAPI.handleIntent(any(), capture(eventHandler)) } answers {
+            eventHandler.captured.onResp(response)
+            true
+        }
+
+        handlePaymentIntentResponse(actionData)
+        component.handleIntent(intent, paymentCompletionHandler)
+        verify(exactly = 1) {
+            paymentCompletionHandler(withArg {
+                assertIs<AirwallexPaymentStatus.Failure>(it).apply {
+                    assertEquals(exception.message, "WeChat Pay has been cancelled!")
+                }
+            })
+        }
+    }
+
+    @Test
+    fun `test handleIntent when WeChat response is other error`() {
+        val eventHandler = slot<IWXAPIEventHandler>()
+        val response = PayResp()
+        response.errCode = BaseResp.ErrCode.ERR_COMM
+        every { wechatAPI.handleIntent(any(), capture(eventHandler)) } answers {
+            eventHandler.captured.onResp(response)
+            true
+        }
+
+        handlePaymentIntentResponse(actionData)
+        component.handleIntent(intent, paymentCompletionHandler)
+        verify(exactly = 1) {
+            paymentCompletionHandler(withArg {
+                assertIs<AirwallexPaymentStatus.Failure>(it).apply {
+                    val errorMsg = requireNotNull(exception.message)
+                    assert(errorMsg.contains("errCode ${BaseResp.ErrCode.ERR_COMM}"))
+                }
+            })
+        }
     }
 
     private fun handlePaymentIntentResponse(actionData: Map<String, Any?>? = null) {

--- a/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
+++ b/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
@@ -130,11 +130,13 @@ class WeChatComponentTest {
         handlePaymentIntentResponse(actionData)
         component.handleIntent(intent, paymentCompletionHandler)
         verify(exactly = 1) {
-            paymentCompletionHandler(withArg {
-                assertIs<AirwallexPaymentStatus.Failure>(it).apply {
-                    assertEquals(exception.message, "WeChat Pay has been cancelled!")
+            paymentCompletionHandler(
+                withArg {
+                    assertIs<AirwallexPaymentStatus.Failure>(it).apply {
+                        assertEquals(exception.message, "WeChat Pay has been cancelled!")
+                    }
                 }
-            })
+            )
         }
     }
 
@@ -151,12 +153,14 @@ class WeChatComponentTest {
         handlePaymentIntentResponse(actionData)
         component.handleIntent(intent, paymentCompletionHandler)
         verify(exactly = 1) {
-            paymentCompletionHandler(withArg {
-                assertIs<AirwallexPaymentStatus.Failure>(it).apply {
-                    val errorMsg = requireNotNull(exception.message)
-                    assert(errorMsg.contains("errCode ${BaseResp.ErrCode.ERR_COMM}"))
+            paymentCompletionHandler(
+                withArg {
+                    assertIs<AirwallexPaymentStatus.Failure>(it).apply {
+                        val errorMsg = requireNotNull(exception.message)
+                        assert(errorMsg.contains("errCode ${BaseResp.ErrCode.ERR_COMM}"))
+                    }
                 }
-            })
+            )
         }
     }
 


### PR DESCRIPTION
So that user can receive ongoing status updates (not just once) from `PaymentResultListener` during wechat payment.