### PR TITLE
[MOB-1862] Fix Wechat Pay inprogress state

### DIFF
--- a/components-core/src/main/java/com/airwallex/android/core/PaymentResultManager.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/PaymentResultManager.kt
@@ -16,7 +16,7 @@ class PaymentResultManager private constructor(private val listener: Airwallex.P
             }
     }
 
-    fun completePayment(status: AirwallexPaymentStatus) {
+    fun updateStatus(status: AirwallexPaymentStatus) {
         listener.onCompleted(status)
     }
 }

--- a/components-core/src/test/java/com/airwallex/android/core/PaymentResultManagerTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/PaymentResultManagerTest.kt
@@ -10,7 +10,7 @@ class PaymentResultManagerTest {
         val listener = mockk<Airwallex.PaymentResultListener>(relaxed = true)
         val manager = PaymentResultManager.getInstance(listener)
         val status = AirwallexPaymentStatus.InProgress("id")
-        manager.completePayment(status)
+        manager.updateStatus(status)
         verify { listener.onCompleted(status) }
     }
 }

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
@@ -34,7 +34,7 @@ class WeChatComponent : ActionComponent {
 
     internal fun handleIntent(
         intent: Intent,
-        onPaymentCompletion: (AirwallexPaymentStatus) -> Unit
+        onCompletion: () -> Unit
     ) {
         weChatApi?.handleIntent(
             intent,
@@ -54,7 +54,8 @@ class WeChatComponent : ActionComponent {
                             AirwallexPaymentStatus.Failure(exception)
                         }
                     }
-                    onPaymentCompletion(status)
+                    listener?.onCompleted(status)
+                    onCompletion()
                 }
             }
         )
@@ -113,7 +114,7 @@ class WeChatComponent : ActionComponent {
                             mapOf("message" to errorMsg)
                         )
                     } else {
-                        listener.onCompleted(AirwallexPaymentStatus.InProgress(paymentIntentId))
+                        PaymentResultManager.getInstance().updateStatus(AirwallexPaymentStatus.InProgress(paymentIntentId))
                         AnalyticsLogger.logPageView(EVENT_NAME)
                     }
                 }

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatPayAuthActivity.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatPayAuthActivity.kt
@@ -2,7 +2,6 @@ package com.airwallex.android.wechat
 
 import android.app.Activity
 import android.os.Bundle
-import com.airwallex.android.core.PaymentResultManager
 
 internal class WeChatPayAuthActivity : Activity() {
 
@@ -15,8 +14,7 @@ internal class WeChatPayAuthActivity : Activity() {
         intent?.let {
             weChatComponent.handleIntent(
                 intent = intent
-            ) { status ->
-                PaymentResultManager.getInstance().completePayment(status)
+            ) {
                 finish()
             }
         }


### PR DESCRIPTION
Before change:
- Finish payment methods activity when Wechat Pay is in progress
- Update payment status when Wechat Pay fails, cancelled or succeeds

After change:
- Update payment status when Wechat Pay is in progress
- Finish payment methods activity when Wechat Pay fails, cancelled or succeeds
