### PR TITLE
[MOB-2068] Allow Google Pay low-level integration

### DIFF
--- a/GUIDE-zh.md
+++ b/GUIDE-zh.md
@@ -40,7 +40,7 @@ Airwallex Android SDK是一种灵活的工具，可让您将付款方式集成�
 
 Airwallex Android SDK是一种灵活的工具，可让您将付款方式集成到您的Android App中。
 
-注意：Airwallex Android SDK与支持Android API级别19及更高版本的应用程序兼容，SDK文件大小约为3188.04KB
+注意：Airwallex Android SDK与支持Android API级别21及更高版本的应用程序兼容，SDK文件大小约为3188.04KB
 
 支持的付款方式：
 - Cards: [`Visa, Mastercard`](#cards). If you want to integrate Airwallex API without our Native UI for card payments, then your website is required to be PCI-DSS compliant. 
@@ -58,7 +58,7 @@ Airwallex Native UI 是一个预构建的UI，可让您自定义UI颜色并适�
 ## 准备集成
 
 ### 添加依赖
-Airwallex Android SDK 支持Android API 19及以上版本。
+Airwallex Android SDK 支持Android API 21及以上版本。
 
 - 安装SDK
 已经上传到[Maven Central](https://repo1.maven.org/maven2/io/github/airwallex/), 你只需要添加Gradle依赖项。

--- a/GUIDE-zh.md
+++ b/GUIDE-zh.md
@@ -214,7 +214,7 @@ Airwallex Android SDK 支持Android API 19及以上版本。
             }
         }
     }
-    val session = buildSessionWithIntent(paymentIntent, customerId)
+    val session = buildSession(paymentIntent, customerId)
     AirwallexStarter.presentPaymentFlow(this, session,
         object : Airwallex.PaymentResultListener {
     
@@ -276,7 +276,7 @@ val paymentSession = AirwallexPaymentSession.Builder(
 
 ### 用卡和账单详情或者consent ID来确认卡支付
 ```kotlin
-val session = buildSessionWithIntent(paymentIntent, customerId)
+val session = buildSession(paymentIntent, customerId)
 val airwallex = Airwallex(this@PaymentCartFragment)
 
 // Confirm intent with card and billing
@@ -301,6 +301,23 @@ airwallex.confirmPaymentIntent(
 airwallex.confirmPaymentIntent(
     session = session,
     paymentConsentId = "cst_xxxxxxxxxx",
+    listener = object : Airwallex.PaymentResultListener {
+        override fun onCompleted(status: AirwallexPaymentStatus) {
+            // You can handle different payment statuses and perform UI action respectively here
+        }
+    }
+)
+```
+
+### 通过Google Pay来发起支付
+```kotlin
+// 注意：我们目前仅支持AirwallexPaymentSession（一次性付款），暂不支持对于Google Pay的recurring session。
+// Also make sure you pass GooglePayOptions to the session.
+val session = buildSession(paymentIntent)
+val airwallex = Airwallex(this@PaymentCartFragment)
+
+airwallex.startGooglePay(
+    session = session,
     listener = object : Airwallex.PaymentResultListener {
         override fun onCompleted(status: AirwallexPaymentStatus) {
             // You can handle different payment statuses and perform UI action respectively here

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -39,7 +39,7 @@ Our demo application is available open source on [Github](https://github.com/air
 
 Airwallex Android SDK is a flexible tool that enables you to integrate payment methods into your Android App. 
 
-Note: The Airwallex Android SDK is compatible with apps supporting Android API level 19 and above and SDK file size is 3188.04KB approximately
+Note: The Airwallex Android SDK is compatible with apps supporting Android API level 21 and above and SDK file size is 3188.04KB approximately
 
 Payment methods supported: 
 - Cards: [`Visa, Mastercard`](#cards). If you want to integrate Airwallex API without our Native UI for card payments, then your website is required to be PCI-DSS compliant. 
@@ -57,7 +57,7 @@ Airwallex Native UI is a prebuilt UI which enables you to customize the UI color
 ## Before you start
 
 ### Step1: Set up SDK
-The Airwallex Android SDK is compatible with apps supporting Android API level 19 and above.
+The Airwallex Android SDK is compatible with apps supporting Android API level 21 and above.
 
 - Install the SDK
 The Components are available through [Maven Central](https://repo1.maven.org/maven2/io/github/airwallex/), you only need to add the Gradle dependency.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -217,7 +217,7 @@ Use `presentShippingFlow` to allow users to provide a shipping address as well a
         }
     }
 
-    val session = buildSessionWithIntent(paymentIntent, customerId)
+    val session = buildSession(paymentIntent, customerId)
     AirwallexStarter.presentPaymentFlow(this, session,
         object : Airwallex.PaymentResultListener {
     
@@ -279,7 +279,7 @@ You can build your own entirely custom UI on top of our low-level APIs.
 
 ### Confirm card payment with card and billing details or payment consent ID
 ```kotlin
-val session = buildSessionWithIntent(paymentIntent, customerId)
+val session = buildSession(paymentIntent, customerId)
 val airwallex = Airwallex(this@PaymentCartFragment)
 
 // Confirm intent with card and billing
@@ -304,6 +304,23 @@ airwallex.confirmPaymentIntent(
 airwallex.confirmPaymentIntent(
     session = session,
     paymentConsentId = "cst_xxxxxxxxxx",
+    listener = object : Airwallex.PaymentResultListener {
+        override fun onCompleted(status: AirwallexPaymentStatus) {
+            // You can handle different payment statuses and perform UI action respectively here
+        }
+    }
+)
+```
+
+### Launch payment via Google Pay
+```kotlin
+// NOTE: We only support AirwallexPaymentSession (one off session), no recurring session for Google Pay at the moment.
+// Also make sure you pass GooglePayOptions to the session.
+val session = buildSession(paymentIntent)
+val airwallex = Airwallex(this@PaymentCartFragment)
+
+airwallex.startGooglePay(
+    session = session,
     listener = object : Airwallex.PaymentResultListener {
         override fun onCompleted(status: AirwallexPaymentStatus) {
             // You can handle different payment statuses and perform UI action respectively here

--- a/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodViewModel.kt
@@ -205,7 +205,7 @@ internal class AddPaymentMethodViewModel(
         private val session: AirwallexSession,
         private val supportedCardSchemes: List<CardScheme>
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
             return AddPaymentMethodViewModel(
                 application, airwallex, session, supportedCardSchemes

--- a/airwallex/src/main/java/com/airwallex/android/view/AirwallexCheckoutViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/AirwallexCheckoutViewModel.kt
@@ -110,7 +110,7 @@ class AirwallexCheckoutViewModel(
         private val airwallex: Airwallex,
         private val session: AirwallexSession
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
             return AirwallexCheckoutViewModel(
                 application, airwallex, session

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
@@ -258,7 +258,7 @@ internal class PaymentMethodsViewModel(
         private val airwallex: Airwallex,
         private val session: AirwallexSession
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
             return PaymentMethodsViewModel(
                 application,

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
@@ -9,7 +9,7 @@ import com.airwallex.android.core.extension.putIfNotNull
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.model.*
 import kotlinx.coroutines.async
-import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.coroutineScope
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -132,7 +132,7 @@ internal class PaymentMethodsViewModel(
             else -> null
         }?.let { clientSecret ->
             TokenManager.updateClientSecret(clientSecret)
-            supervisorScope {
+            coroutineScope {
                 val retrieveConsents = async {
                     customerId?.let {
                         retrieveAvailablePaymentConsents(clientSecret, it)

--- a/android-module.gradle
+++ b/android-module.gradle
@@ -47,12 +47,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
         freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,12 @@ ext {
     compileSdkVersion = 34
     minSdkVersion = 21
 
-    kotlinCoroutinesVersion = '1.5.2'
+    kotlinCoroutinesVersion = '1.8.0'
 
     wechatPayVersion = "6.8.0"
 
     junitVersion = '4.13.2'
-    robolectricVersion = '4.10.3'
+    robolectricVersion = '4.12.2'
     testCoreVersion = '1.5.0'
 
     versionCode = System.getenv("AIRWALLEX_VERSION_CODE") as Integer ?: 1

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import io.gitlab.arturbosch.detekt.Detekt
 
 buildscript {
     ext {
-        kotlinVersion = '1.7.20'
+        kotlinVersion = '1.8.0'
         jacocoVersion = '0.8.8'
         detektVersion = '1.21.0'
     }
@@ -48,7 +48,7 @@ tasks.register('clean', Delete) {
 version = '4.4.7'
 
 ext {
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     minSdkVersion = 21
 
     kotlinCoroutinesVersion = '1.5.2'

--- a/card/src/main/java/com/airwallex/android/card/CardComponent.kt
+++ b/card/src/main/java/com/airwallex/android/card/CardComponent.kt
@@ -129,14 +129,16 @@ class CardComponent : ActionComponent {
             }
             return true
         } else if (requestCode == ThreeDSecurityActivityLaunch.REQUEST_CODE) {
-            val result = ThreeDSecurityActivityLaunch.Result.fromIntent(data)
-            result?.paymentIntentId?.let {
-                listener?.onCompleted(AirwallexPaymentStatus.Success(it))
-            }
-            result?.exception?.let {
-                listener?.onCompleted(AirwallexPaymentStatus.Failure(it))
-            }
-            return true
+            listener?.let {
+                val result = ThreeDSecurityActivityLaunch.Result.fromIntent(data)
+                result?.paymentIntentId?.let { intentId ->
+                    it.onCompleted(AirwallexPaymentStatus.Success(intentId))
+                }
+                result?.exception?.let { exception ->
+                    it.onCompleted(AirwallexPaymentStatus.Failure(exception))
+                }
+                return true
+            } ?: return false
         }
         return false
     }

--- a/card/src/main/java/com/airwallex/android/card/CardComponent.kt
+++ b/card/src/main/java/com/airwallex/android/card/CardComponent.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.card
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.fragment.app.Fragment
 
 import com.airwallex.android.card.exception.DccException
 import com.airwallex.android.card.view.DccActivityLaunch
@@ -27,6 +28,7 @@ class CardComponent : ActionComponent {
     override fun handlePaymentIntentResponse(
         paymentIntentId: String,
         nextAction: NextAction?,
+        fragment: Fragment?,
         activity: Activity,
         applicationContext: Context,
         cardNextActionModel: CardNextActionModel?,
@@ -38,7 +40,6 @@ class CardComponent : ActionComponent {
             return
         }
 
-        val fragment = cardNextActionModel.fragment
         val dccActivityLaunch: DccActivityLaunch = if (fragment != null) {
             DccActivityLaunch(fragment)
         } else {

--- a/card/src/main/java/com/airwallex/android/card/CardComponent.kt
+++ b/card/src/main/java/com/airwallex/android/card/CardComponent.kt
@@ -92,6 +92,7 @@ class CardComponent : ActionComponent {
                 ThreeDSecurityManager.handleThreeDSFlow(
                     paymentIntentId = paymentIntentId,
                     activity = activity,
+                    fragment = fragment,
                     nextAction = nextAction,
                     cardNextActionModel = cardNextActionModel,
                     listener = listener

--- a/card/src/main/java/com/airwallex/android/card/view/DccViewModel.kt
+++ b/card/src/main/java/com/airwallex/android/card/view/DccViewModel.kt
@@ -40,7 +40,7 @@ internal class DccViewModel(
         private val application: Application,
         private val airwallex: Airwallex
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
             return DccViewModel(
                 application, airwallex

--- a/card/src/test/java/com/airwallex/android/card/CardComponentProviderTest.kt
+++ b/card/src/test/java/com/airwallex/android/card/CardComponentProviderTest.kt
@@ -109,8 +109,6 @@ class CardComponentProviderTest {
             activity,
             context,
             CardNextActionModel(
-                fragment = null,
-                activity = activity,
                 paymentManager = AirwallexPaymentManager(AirwallexApiRepository()),
                 clientSecret = "tqj9uJlZZ8NIFEM_dpZb2DXbGkQ==",
                 device = null,

--- a/card/src/test/java/com/airwallex/android/card/CardComponentProviderTest.kt
+++ b/card/src/test/java/com/airwallex/android/card/CardComponentProviderTest.kt
@@ -105,6 +105,7 @@ class CardComponentProviderTest {
                 url = null,
                 method = "POST"
             ),
+            null,
             activity,
             context,
             CardNextActionModel(

--- a/card/src/test/java/com/airwallex/android/card/CardComponentTest.kt
+++ b/card/src/test/java/com/airwallex/android/card/CardComponentTest.kt
@@ -53,8 +53,6 @@ class CardComponentTest {
             method = null
         )
         val cardModel = CardNextActionModel(
-            fragment = null,
-            activity = activity,
             paymentManager = AirwallexPaymentManager(AirwallexApiRepository()),
             clientSecret = "tqj9uJlZZ8NIFEM_dpZb2DXbGkQ==",
             device = null,
@@ -64,7 +62,7 @@ class CardComponentTest {
         )
         handlePaymentIntentResponse(redirectAction, cardModel)
         verify(exactly = 1) {
-            ThreeDSecurityManager.handleThreeDSFlow("id", activity, redirectAction, cardModel, listener)
+            ThreeDSecurityManager.handleThreeDSFlow("id", activity, null, redirectAction, cardModel, listener)
         }
     }
 

--- a/components-core/build.gradle
+++ b/components-core/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-android-extensions-runtime:$kotlinVersion"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.0"
     implementation "io.github.airwallex:AirTracker:1.0.3"
 
     // test

--- a/components-core/build.gradle
+++ b/components-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation "androidx.test:core:$testCoreVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0'
     testImplementation 'io.mockk:mockk:1.13.3'
 }
 

--- a/components-core/build.gradle
+++ b/components-core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api 'com.google.android.material:material:1.4.0'
 
     // kotlin
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-parcelize-runtime:$kotlinVersion"
     api "org.jetbrains.kotlin:kotlin-android-extensions-runtime:$kotlinVersion"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"

--- a/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.core
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.fragment.app.Fragment
 import com.airwallex.android.core.model.NextAction
 
 interface ActionComponent {
@@ -10,6 +11,7 @@ interface ActionComponent {
     fun handlePaymentIntentResponse(
         paymentIntentId: String,
         nextAction: NextAction?,
+        fragment: Fragment? = null,
         activity: Activity,
         applicationContext: Context,
         cardNextActionModel: CardNextActionModel?,

--- a/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
@@ -8,6 +8,7 @@ import com.airwallex.android.core.model.NextAction
 
 interface ActionComponent {
 
+    @Suppress("LongParameterList")
     fun handlePaymentIntentResponse(
         paymentIntentId: String,
         nextAction: NextAction?,

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -377,6 +377,7 @@ class Airwallex internal constructor(
                     provider.get().handlePaymentIntentResponse(
                         paymentIntentId,
                         response.nextAction,
+                        fragment,
                         activity,
                         applicationContext,
                         cardNextActionModel,
@@ -676,18 +677,10 @@ class Airwallex internal constructor(
             googlePayProvider.get().handlePaymentIntentResponse(
                 paymentIntentId = session.paymentIntent.id,
                 nextAction = null,
+                fragment = fragment,
                 activity = activity,
                 applicationContext = applicationContext,
-                cardNextActionModel = CardNextActionModel(
-                    fragment = fragment,
-                    activity = activity,
-                    paymentManager = paymentManager,
-                    clientSecret = requireNotNull(session.paymentIntent.clientSecret),
-                    device = null,
-                    paymentIntentId = session.paymentIntent.id,
-                    currency = session.currency,
-                    amount = session.amount
-                ),
+                cardNextActionModel = null,
                 listener = object : PaymentResultListener {
                     override fun onCompleted(status: AirwallexPaymentStatus) {
                         when (status) {
@@ -871,6 +864,7 @@ class Airwallex internal constructor(
                     provider.get().handlePaymentIntentResponse(
                         response.id,
                         response.nextAction,
+                        fragment,
                         activity,
                         applicationContext,
                         cardNextActionModel,
@@ -1056,6 +1050,7 @@ class Airwallex internal constructor(
                 provider.get().handlePaymentIntentResponse(
                     response.id,
                     response.nextAction,
+                    fragment,
                     activity,
                     applicationContext,
                     CardNextActionModel(

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -678,7 +678,16 @@ class Airwallex internal constructor(
                 nextAction = null,
                 activity = activity,
                 applicationContext = applicationContext,
-                cardNextActionModel = null,
+                cardNextActionModel = CardNextActionModel(
+                    fragment = fragment,
+                    activity = activity,
+                    paymentManager = paymentManager,
+                    clientSecret = requireNotNull(session.paymentIntent.clientSecret),
+                    device = null,
+                    paymentIntentId = session.paymentIntent.id,
+                    currency = session.currency,
+                    amount = session.amount
+                ),
                 listener = object : PaymentResultListener {
                     override fun onCompleted(status: AirwallexPaymentStatus) {
                         when (status) {

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -172,7 +172,7 @@ class Airwallex internal constructor(
      * @param listener The callback of the payment flow
      */
     @UiThread
-    fun confirmPaymentIntent(
+    fun startGooglePay(
         session: AirwallexPaymentSession,
         listener: PaymentResultListener
     ) {
@@ -197,7 +197,7 @@ class Airwallex internal constructor(
             }
         } else {
             listener.onCompleted(
-                AirwallexPaymentStatus.Failure(AirwallexCheckoutException(message = "GooglePay not available."))
+                AirwallexPaymentStatus.Failure(AirwallexCheckoutException(message = "Google Pay component is not available."))
             )
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -368,8 +368,6 @@ class Airwallex internal constructor(
                     val paymentIntentId = requireNotNull(response.initialPaymentIntentId)
                     val cardNextActionModel = when (params.paymentMethodType) {
                         PaymentMethodType.CARD.value -> CardNextActionModel(
-                            fragment = fragment,
-                            activity = activity,
                             paymentManager = paymentManager,
                             clientSecret = params.clientSecret,
                             device = null,
@@ -849,8 +847,6 @@ class Airwallex internal constructor(
                 override fun onSuccess(response: PaymentIntent) {
                     val cardNextActionModel = when (params.paymentMethodType) {
                         PaymentMethodType.CARD.value -> CardNextActionModel(
-                            fragment = fragment,
-                            activity = activity,
                             paymentManager = paymentManager,
                             clientSecret = params.clientSecret,
                             device = device,
@@ -1061,8 +1057,6 @@ class Airwallex internal constructor(
                     activity,
                     applicationContext,
                     CardNextActionModel(
-                        fragment = fragment,
-                        activity = activity,
                         paymentManager = paymentManager,
                         clientSecret = params.clientSecret,
                         device = params.device,

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -7,7 +7,6 @@ import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.lifecycleScope
 import com.airwallex.android.core.exception.AirwallexException
 import com.airwallex.android.core.exception.AirwallexCheckoutException
@@ -16,9 +15,6 @@ import com.airwallex.android.core.extension.confirmGooglePayIntent
 import com.airwallex.android.core.extension.createCardPaymentMethod
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.model.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import java.math.BigDecimal

--- a/components-core/src/main/java/com/airwallex/android/core/CardNextActionModel.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/CardNextActionModel.kt
@@ -1,13 +1,9 @@
 package com.airwallex.android.core
 
-import android.app.Activity
-import androidx.fragment.app.Fragment
 import com.airwallex.android.core.model.Device
 import java.math.BigDecimal
 
 class CardNextActionModel(
-    val fragment: Fragment?,
-    val activity: Activity,
     val paymentManager: PaymentManager,
     val clientSecret: String,
     val device: Device?,

--- a/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
@@ -57,8 +57,6 @@ internal fun ActionComponent.confirmGooglePayIntent(
                         override fun onSuccess(response: PaymentIntent) {
                             if (response.nextAction != null) {
                                 val cardNextActionModel = CardNextActionModel(
-                                    fragment = fragment,
-                                    activity = activity,
                                     paymentManager = paymentManager,
                                     clientSecret = clientSecret,
                                     device = device,

--- a/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
@@ -24,6 +24,7 @@ internal fun ActionComponent.confirmGooglePayIntent(
     retrieveSecurityToken(
         paymentIntentId, applicationContext,
         object : SecurityTokenListener {
+            @Suppress("LongMethod")
             override fun onResponse(deviceId: String) {
                 val device = paymentManager.buildDeviceInfo(deviceId)
                 val threeDSecure = ThreeDSecure.Builder()

--- a/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
@@ -68,6 +68,7 @@ internal fun ActionComponent.confirmGooglePayIntent(
                                 handlePaymentIntentResponse(
                                     response.id,
                                     response.nextAction,
+                                    fragment,
                                     activity,
                                     applicationContext,
                                     cardNextActionModel,

--- a/components-core/src/main/java/com/airwallex/android/core/model/Dependency.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/model/Dependency.kt
@@ -3,5 +3,6 @@ package com.airwallex.android.core.model
 enum class Dependency(val value: String) {
     CARD("payment-card"),
     WECHAT("payment-wechat"),
-    REDIRECT("payment-redirect")
+    REDIRECT("payment-redirect"),
+    GOOGLEPAY("payment-googlepay")
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentManagerTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentManagerTest.kt
@@ -33,15 +33,19 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.json.JSONObject
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class AirwallexPaymentManagerTest {
+    private lateinit var dispatcher: TestDispatcher
+
     private lateinit var paymentManager: PaymentManager
     private val clientSecret = "qadf"
     private val consentId = "cid"
@@ -57,8 +61,8 @@ class AirwallexPaymentManagerTest {
     @Before
     fun setUp() {
         mockkObject(BuildHelper)
-        val testDispatcher = UnconfinedTestDispatcher()
-        Dispatchers.setMain(testDispatcher)
+        dispatcher = UnconfinedTestDispatcher()
+        Dispatchers.setMain(dispatcher)
 
         mockResponse = PageParser(AvailablePaymentMethodTypeParser()).parse(
             JSONObject(
@@ -118,6 +122,11 @@ class AirwallexPaymentManagerTest {
         paymentManager = AirwallexPaymentManager(apiRepository)
     }
 
+    @After
+    fun unmockk() {
+        unmockkAll()
+    }
+
     @Test
     fun `test retrieveAvailablePaymentMethods`() = runTest {
         val options = mockk<Options.RetrieveAvailablePaymentMethodsOptions>()
@@ -165,8 +174,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start RetrievePaymentConsentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>()
+    fun `test start RetrievePaymentConsentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>(relaxed = true)
         paymentManager.startOperation(
             Options.RetrievePaymentConsentOptions(
                 clientSecret,
@@ -178,8 +187,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start DisablePaymentConsentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>()
+    fun `test start DisablePaymentConsentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>(relaxed = true)
         paymentManager.startOperation(
             Options.DisablePaymentConsentOptions(
                 clientSecret,
@@ -192,8 +201,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start VerifyPaymentConsentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>()
+    fun `test start VerifyPaymentConsentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>(relaxed = true)
         paymentManager.startOperation(
             Options.VerifyPaymentConsentOptions(
                 clientSecret,
@@ -206,8 +215,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start CreatePaymentConsentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>()
+    fun `test start CreatePaymentConsentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentConsent>>(relaxed = true)
         paymentManager.startOperation(
             Options.CreatePaymentConsentOptions(
                 clientSecret,
@@ -219,8 +228,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start RetrieveAvailablePaymentMethodsOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<Page<AvailablePaymentMethodType>>>()
+    fun `test start RetrieveAvailablePaymentMethodsOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<Page<AvailablePaymentMethodType>>>(relaxed = true)
         paymentManager.startOperation(
             Options.RetrieveAvailablePaymentMethodsOptions(
                 clientSecret,
@@ -237,8 +246,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start CreatePaymentMethodOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentMethod>>()
+    fun `test start CreatePaymentMethodOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentMethod>>(relaxed = true)
         paymentManager.startOperation(
             Options.CreatePaymentMethodOptions(
                 clientSecret,
@@ -250,8 +259,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start RetrievePaymentIntentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>()
+    fun `test start RetrievePaymentIntentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>(relaxed = true)
         paymentManager.startOperation(
             Options.RetrievePaymentIntentOptions(
                 clientSecret,
@@ -263,8 +272,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start ConfirmPaymentIntentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>()
+    fun `test start ConfirmPaymentIntentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>(relaxed = true)
         paymentManager.startOperation(
             Options.ConfirmPaymentIntentOptions(
                 clientSecret,
@@ -277,8 +286,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start ContinuePaymentIntentOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>()
+    fun `test start ContinuePaymentIntentOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentIntent>>(relaxed = true)
         paymentManager.startOperation(
             Options.ContinuePaymentIntentOptions(
                 clientSecret,
@@ -291,8 +300,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start RetrievePaymentMethodTypeInfoOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<PaymentMethodTypeInfo>>()
+    fun `test start RetrievePaymentMethodTypeInfoOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<PaymentMethodTypeInfo>>(relaxed = true)
         paymentManager.startOperation(
             Options.RetrievePaymentMethodTypeInfoOptions(
                 clientSecret,
@@ -308,8 +317,8 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start RetrieveBankOptions operation`() {
-        val listener = mockk<Airwallex.PaymentListener<BankResponse>>()
+    fun `test start RetrieveBankOptions operation`() = runTest {
+        val listener = mockk<Airwallex.PaymentListener<BankResponse>>(relaxed = true)
         paymentManager.startOperation(
             Options.RetrieveBankOptions(
                 clientSecret,
@@ -325,7 +334,7 @@ class AirwallexPaymentManagerTest {
     }
 
     @Test
-    fun `test start TrackerOptions operation`() {
+    fun `test start TrackerOptions operation`() = runTest {
         mockkObject(AnalyticsLogger)
         val testUrl = "http://abc.com"
         mockkStatic((Uri::class))
@@ -349,7 +358,5 @@ class AirwallexPaymentManagerTest {
             )
         }
         verify { listener.onFailed(any()) }
-
-        unmockkAll()
     }
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.core
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.fragment.app.Fragment
 import com.airwallex.android.core.model.AvailablePaymentMethodType
 import com.airwallex.android.core.model.AvailablePaymentMethodTypeResource
 import com.airwallex.android.core.model.NextAction
@@ -30,6 +31,7 @@ class AirwallexPluginsTest {
         override fun handlePaymentIntentResponse(
             paymentIntentId: String,
             nextAction: NextAction?,
+            fragment: Fragment?,
             activity: Activity,
             applicationContext: Context,
             cardNextActionModel: CardNextActionModel?,

--- a/components-core/src/test/java/com/airwallex/android/core/extension/ActionComponentProviderExtensionsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/extension/ActionComponentProviderExtensionsTest.kt
@@ -58,6 +58,7 @@ class ActionComponentProviderExtensionsTest {
             actionComponent.handlePaymentIntentResponse(
                 paymentIntent.id,
                 paymentIntent.nextAction,
+                fragment,
                 activity,
                 context,
                 any(),

--- a/components-core/src/test/java/com/airwallex/android/core/model/DependencyTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/model/DependencyTest.kt
@@ -1,0 +1,14 @@
+package com.airwallex.android.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DependencyTest {
+    @Test
+    fun testMapping() {
+        assertEquals("payment-card", Dependency.CARD.value)
+        assertEquals("payment-wechat", Dependency.WECHAT.value)
+        assertEquals("payment-redirect", Dependency.REDIRECT.value)
+        assertEquals("payment-googlepay", Dependency.GOOGLEPAY.value)
+    }
+}

--- a/googlepay/build.gradle
+++ b/googlepay/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     api project(':security-3ds')
 
     implementation 'androidx.activity:activity-ktx:1.9.0'
-    implementation 'com.google.android.gms:play-services-wallet:19.3.0'
+    implementation 'com.google.android.gms:play-services-wallet:19.4.0'
 
     testImplementation 'org.json:json:20231013'
     testImplementation "junit:junit:$junitVersion"

--- a/googlepay/build.gradle
+++ b/googlepay/build.gradle
@@ -13,11 +13,12 @@ dependencies {
     api project(':ui-core')
     api project(':security-3ds')
 
-    implementation 'com.google.android.gms:play-services-wallet:19.2.1'
+    implementation 'androidx.activity:activity-ktx:1.9.0'
+    implementation 'com.google.android.gms:play-services-wallet:19.3.0'
 
     testImplementation 'org.json:json:20231013'
     testImplementation "junit:junit:$junitVersion"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0'
     testImplementation 'io.mockk:mockk:1.13.3'
 }
 

--- a/googlepay/src/main/AndroidManifest.xml
+++ b/googlepay/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
             android:name=".GooglePayLauncherActivity"
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
-            android:theme="@style/AirwallexDefaultTheme" />
+            android:theme="@style/AirwallexTransparentTheme" />
     </application>
 
 </manifest>

--- a/googlepay/src/main/AndroidManifest.xml
+++ b/googlepay/src/main/AndroidManifest.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application tools:targetApi="n">
+        <activity
+            android:name=".GooglePayLauncherActivity"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait"
+            android:theme="@style/AirwallexDefaultTheme" />
+    </application>
+
+</manifest>

--- a/googlepay/src/main/AndroidManifest.xml
+++ b/googlepay/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
         <activity
             android:name=".GooglePayLauncherActivity"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait"
             android:theme="@style/AirwallexTransparentTheme" />
     </application>
 

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayActivityLaunch.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayActivityLaunch.kt
@@ -1,0 +1,77 @@
+package com.airwallex.android.googlepay
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import com.airwallex.android.core.AirwallexSession
+import com.airwallex.android.core.GooglePayOptions
+import com.airwallex.android.core.exception.AirwallexException
+import com.airwallex.android.core.model.AvailablePaymentMethodType
+import com.airwallex.android.googlepay.GooglePayActivityLaunch.Args
+import com.airwallex.android.ui.AirwallexActivityLaunch
+import com.airwallex.android.ui.extension.getExtraResult
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+
+internal class GooglePayActivityLaunch :
+    AirwallexActivityLaunch<GooglePayLauncherActivity, Args> {
+
+    constructor(activity: Activity) : super(
+        activity,
+        GooglePayLauncherActivity::class.java,
+        REQUEST_CODE
+    )
+
+    constructor(fragment: Fragment) : super(
+        fragment,
+        GooglePayLauncherActivity::class.java,
+        REQUEST_CODE
+    )
+
+    @Parcelize
+    internal data class Args(
+        val session: AirwallexSession,
+        val googlePayOptions: GooglePayOptions,
+        val paymentMethodType: AvailablePaymentMethodType
+    ) : AirwallexActivityLaunch.Args
+
+    internal sealed class Result : AirwallexActivityLaunch.Result {
+        @Parcelize
+        data class Success(val info: @RawValue Map<String, Any>) : Result() {
+            override fun toBundle(): Bundle {
+                return Bundle().also {
+                    it.putParcelable(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA, this)
+                }
+            }
+        }
+
+        @Parcelize
+        data class Failure(val exception: AirwallexException) : Result() {
+            override fun toBundle(): Bundle {
+                return Bundle().also {
+                    it.putParcelable(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA, this)
+                }
+            }
+        }
+
+        @Parcelize
+        object Cancel : Result() {
+            override fun toBundle(): Bundle {
+                return Bundle().also {
+                    it.putParcelable(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA, this)
+                }
+            }
+        }
+
+        companion object {
+            fun fromIntent(intent: Intent?): Result? {
+                return intent?.getExtraResult()
+            }
+        }
+    }
+
+    companion object {
+        const val REQUEST_CODE: Int = 1007
+    }
+}

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponent.kt
@@ -50,6 +50,7 @@ class GooglePayComponent : ActionComponent {
             ThreeDSecurityManager.handleThreeDSFlow(
                 paymentIntentId = paymentIntentId,
                 activity = activity,
+                fragment = fragment,
                 nextAction = nextAction,
                 cardNextActionModel = cardNextActionModel,
                 listener = listener

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayLauncherActivity.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayLauncherActivity.kt
@@ -1,0 +1,116 @@
+package com.airwallex.android.googlepay
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.airwallex.android.core.exception.AirwallexCheckoutException
+import com.airwallex.android.core.model.Billing
+import com.airwallex.android.ui.extension.getExtraArgs
+import com.google.android.gms.common.api.CommonStatusCodes
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.wallet.PaymentData
+import com.google.android.gms.wallet.PaymentDataRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.contract.ApiTaskResult
+import com.google.android.gms.wallet.contract.TaskResultContracts.GetPaymentDataResult
+import org.json.JSONException
+import org.json.JSONObject
+
+class GooglePayLauncherActivity : ComponentActivity() {
+    // A client for interacting with the Google Pay API.
+    private val paymentsClient: PaymentsClient by lazy {
+        PaymentsUtil.createPaymentsClient(this)
+    }
+
+    private val args: GooglePayActivityLaunch.Args by lazy {
+        intent.getExtraArgs()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val googlePayLauncher = registerForActivityResult(GetPaymentDataResult()) {
+            onGooglePayResult(it)
+        }
+
+        val task = getLoadPaymentDataTask()
+        task.addOnCompleteListener(googlePayLauncher::launch)
+    }
+
+    private fun getLoadPaymentDataTask(): Task<PaymentData> {
+        val session = args.session
+        val paymentDataRequestJson = PaymentsUtil.getPaymentDataRequest(
+            price = session.amount,
+            countryCode = session.countryCode,
+            currency = session.currency,
+            googlePayOptions = args.googlePayOptions,
+            supportedCardSchemes = args.paymentMethodType.cardSchemes
+        )
+        val request = PaymentDataRequest.fromJson(paymentDataRequestJson.toString())
+        return paymentsClient.loadPaymentData(request)
+    }
+
+    private fun onGooglePayResult(taskResult: ApiTaskResult<PaymentData>) {
+        when (taskResult.status.statusCode) {
+            CommonStatusCodes.SUCCESS -> {
+                val result = taskResult.result
+                if (result != null) {
+                    val successInfo = createPaymentSuccessInfo(result)
+                    if (successInfo != null) {
+                        finishWithResult(
+                            GooglePayActivityLaunch.Result.Success(successInfo)
+                        )
+                    } else {
+                        finishWithResult(
+                            GooglePayActivityLaunch.Result.Failure(
+                                AirwallexCheckoutException(message = "Missing Google Pay token response")
+                            )
+                        )
+                    }
+                } else {
+
+                }
+            }
+            CommonStatusCodes.CANCELED -> finishWithResult(
+                GooglePayActivityLaunch.Result.Cancel
+            )
+        }
+    }
+
+    private fun finishWithResult(result: GooglePayActivityLaunch.Result) {
+        setResult(
+            RESULT_OK,
+            Intent()
+                .putExtras(
+                    result.toBundle()
+                )
+        )
+        finish()
+    }
+
+    private fun createPaymentSuccessInfo(paymentData: PaymentData): Map<String, Any>? {
+        val paymentInformation = paymentData.toJson()
+        val info = mutableMapOf<String, Any>().apply {
+            try {
+                val paymentMethodData =
+                    JSONObject(paymentInformation).getJSONObject("paymentMethodData")
+                put("payment_data_type", "encrypted_payment_token")
+                // Token will be null if PaymentDataRequest was not constructed using fromJson(String).
+                put(
+                    "encrypted_payment_token",
+                    paymentMethodData.getJSONObject("tokenizationData").getString("token")
+                )
+                paymentMethodData.optJSONObject("info").optJSONObject("billingAddress")
+                    ?.let { billingAddress ->
+                        PaymentsUtil.getBilling(billingAddress)?.let {
+                            put("billing", it)
+                        }
+                    }
+            } catch (e: JSONException) {
+
+                return null
+            }
+        }
+        return info
+    }
+}

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
@@ -95,8 +95,6 @@ class GooglePayComponentTest {
             method = null
         )
         val cardModel = CardNextActionModel(
-            fragment = null,
-            activity = activity,
             paymentManager = AirwallexPaymentManager(AirwallexApiRepository()),
             clientSecret = "tqj9uJlZZ8NIFEM_dpZb2DXbGkQ==",
             device = null,
@@ -109,6 +107,7 @@ class GooglePayComponentTest {
             ThreeDSecurityManager.handleThreeDSFlow(
                 "id",
                 activity,
+                null,
                 redirectAction,
                 cardModel,
                 listener

--- a/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/airwallex/android/googlepay/GooglePayComponentTest.kt
@@ -1,21 +1,18 @@
 package com.airwallex.android.googlepay
 
 import android.app.Activity
-import android.app.Activity.RESULT_CANCELED
 import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
-import android.os.SystemClock
 import com.airwallex.android.core.*
-import com.airwallex.android.core.log.AnalyticsLogger
+import com.airwallex.android.core.exception.AirwallexException
 import com.airwallex.android.core.model.*
 import com.airwallex.android.core.model.parser.AvailablePaymentMethodTypeParser
 import com.airwallex.android.core.model.parser.PageParser
 import com.airwallex.android.threedsecurity.AirwallexSecurityConnector
+import com.airwallex.android.threedsecurity.ThreeDSecurityActivityLaunch
 import com.airwallex.android.threedsecurity.ThreeDSecurityManager
-import com.google.android.gms.common.api.Status
-import com.google.android.gms.tasks.Task
-import com.google.android.gms.wallet.*
+import com.airwallex.android.ui.extension.getExtraResult
 import io.mockk.*
 import org.json.JSONObject
 import org.junit.After
@@ -29,7 +26,6 @@ class GooglePayComponentTest {
     private lateinit var activity: Activity
     private lateinit var context: Context
     private lateinit var listener: Airwallex.PaymentResultListener
-    private lateinit var mockTask: Task<PaymentData>
 
     private val mockResponse: Page<AvailablePaymentMethodType> =
         PageParser(AvailablePaymentMethodTypeParser()).parse(
@@ -54,54 +50,26 @@ class GooglePayComponentTest {
 
     @Before
     fun setUp() {
-        mockkObject(AnalyticsLogger)
-        mockkStatic(PaymentDataRequest::class)
-        mockkStatic(PaymentsUtil::class)
-        mockkStatic(Wallet::class)
-        mockkStatic(PaymentsClient::class)
-        mockkStatic(SystemClock::class)
-        mockkStatic(PaymentData::class)
-        mockkStatic(AutoResolveHelper::class)
         mockkObject(ThreeDSecurityManager)
         mockkConstructor(AirwallexSecurityConnector::class)
+        mockkConstructor(GooglePayActivityLaunch::class)
         component = GooglePayComponent()
 
+        every { anyConstructed<GooglePayActivityLaunch>().startForResult(any()) } just runs
         val session = mockk<AirwallexSession>(relaxed = true)
         val mockPaymentType = mockk<AvailablePaymentMethodType>()
-        val mockResolver =
-            mockk<(task: Task<PaymentData>, activity: Activity, requestCode: Int) -> Unit>(relaxed = true)
-        component.resolvePaymentRequest = mockResolver
         component.session = session
-        component.paymentMethodType = mockResponse.items?.first() ?: mockPaymentType
+        component.paymentMethodType = mockResponse.items.first() ?: mockPaymentType
         activity = mockk()
         context = mockk()
-        val mockClient = mockk<PaymentsClient>()
-        val mockRequest = mockk<PaymentDataRequest>()
         listener = mockk(relaxed = true)
-        mockTask = mockk()
-        every { PaymentDataRequest.fromJson(any()) } returns mockRequest
-        every { mockClient.loadPaymentData(mockRequest) } returns mockTask
-        every { PaymentsUtil.createPaymentsClient(activity) } returns mockClient
     }
 
     @After
     fun unmockStatics() {
-        unmockkObject(AnalyticsLogger)
-        unmockkStatic(PaymentDataRequest::class)
-        unmockkStatic(PaymentsUtil::class)
-        unmockkStatic(Wallet::class)
-        unmockkStatic(PaymentsClient::class)
-        unmockkStatic(SystemClock::class)
-        unmockkStatic(PaymentData::class)
-        unmockkStatic(AutoResolveHelper::class)
         unmockkObject(ThreeDSecurityManager)
         unmockkConstructor(AirwallexSecurityConnector::class)
-    }
-
-    @Test
-    fun `test handlePaymentIntentResponse when payment data request is valid`() {
-        handlePaymentIntentResponse()
-        verify(exactly = 1) { component.resolvePaymentRequest(mockTask, activity, 991) }
+        unmockkConstructor(GooglePayActivityLaunch::class)
     }
 
     @Test
@@ -154,87 +122,70 @@ class GooglePayComponentTest {
     }
 
     @Test
-    fun `test handleActivityResult when result code is cancelled`() {
-        handlePaymentIntentResponse()
-        component.handleActivityResult(991, RESULT_CANCELED, null)
-        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Cancel) }
-        verify(exactly = 1) { AnalyticsLogger.logPageView("google_pay_sheet", mapOf("code" to RESULT_CANCELED)) }
+    fun `test handleActivityResult when listener is null`() {
+        val intent = mockk<Intent>()
+        assertFalse(component.handleActivityResult(1006, RESULT_OK, intent))
     }
 
     @Test
-    fun `test handleActivityResult when result code is error`() {
-        val intentData = mockk<Intent>()
-        every { SystemClock.elapsedRealtime() } returns 0
-        every { AutoResolveHelper.getStatusFromIntent(intentData) } returns Status.RESULT_INTERNAL_ERROR
+    fun `test handleActivityResult when result is 3ds success`() {
+        val intent = mockk<Intent>()
+        val result = mockk<ThreeDSecurityActivityLaunch.Result>(relaxed = true)
+        every { result.paymentIntentId } returns "intentId"
+        every { intent.getExtraResult<ThreeDSecurityActivityLaunch.Result>() } returns result
+
         handlePaymentIntentResponse()
-        component.handleActivityResult(991, AutoResolveHelper.RESULT_ERROR, intentData)
-        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Cancel) }
-        verify(exactly = 1) {
-            AnalyticsLogger.logError(
-                "googlepay_payment_data_retrieve",
-                mapOf("code" to Status.RESULT_INTERNAL_ERROR.statusCode.toString())
-            )
-        }
+        assert(component.handleActivityResult(1006, RESULT_OK, intent))
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Success("intentId")) }
     }
 
     @Test
-    fun `test handleActivityResult when result code is OK with intent data`() {
-        val mockResponseJson =
-            "{\"paymentMethodData\":{\"info\":{\"billingAddress\":{\"address1\":\"10 Collins St\"," +
-                    "\"address2\":\"\",\"address3\":\"\",\"administrativeArea\":\"VIC\",\"countryCode\":\"AU\"," +
-                    "\"locality\":\"Melbourne\",\"name\":\"John Citizen\",\"postalCode\":\"3000\"," +
-                    "\"sortingCode\":\"\"}},\"tokenizationData\":{\"token\":\"MEUCIAzbCIvhBuBvH3Pz\"}}}"
-        val mockData = mockk<Intent>()
-        val paymentData = mockk<PaymentData>()
-        every { paymentData.toJson() } returns mockResponseJson
-        every { PaymentData.getFromIntent(mockData) } returns paymentData
+    fun `test handleActivityResult when result is 3ds fail`() {
+        val intent = mockk<Intent>()
+        val result = mockk<ThreeDSecurityActivityLaunch.Result>(relaxed = true)
+        val exception = mockk<AirwallexException>()
+        every { result.exception } returns exception
+        every { intent.getExtraResult<ThreeDSecurityActivityLaunch.Result>() } returns result
 
         handlePaymentIntentResponse()
-        component.handleActivityResult(991, RESULT_OK, mockData)
-        val billing = Billing.Builder().setAddress(
-            Address.Builder()
-                .setCity("Melbourne")
-                .setCountryCode("AU")
-                .setPostcode("3000")
-                .setState("VIC")
-                .setStreet("10 Collins St")
-                .build()
+        assert(component.handleActivityResult(1006, RESULT_OK, intent))
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Failure(exception)) }
+    }
+
+    @Test
+    fun `test handleActivityResult when result is google pay cancel`() {
+        val intent = mockk<Intent>()
+        every { intent.getExtraResult<GooglePayActivityLaunch.Result>() } returns GooglePayActivityLaunch.Result.Cancel
+
+        handlePaymentIntentResponse()
+        assert(component.handleActivityResult(1007, RESULT_OK, intent))
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Cancel) }
+    }
+
+    @Test
+    fun `test handleActivityResult when result is google pay fail`() {
+        val intent = mockk<Intent>()
+        val exception = mockk<AirwallexException>()
+        every { intent.getExtraResult<GooglePayActivityLaunch.Result>() } returns GooglePayActivityLaunch.Result.Failure(
+            exception
         )
-            .setFirstName("John")
-            .setLastName("Citizen")
-            .build()
-        verify {
-            listener.onCompleted(
-                AirwallexPaymentStatus.Success(
-                    "id",
-                    mapOf(
-                        "payment_data_type" to "encrypted_payment_token",
-                        "encrypted_payment_token" to "MEUCIAzbCIvhBuBvH3Pz",
-                        "billing" to billing
-                    )
-                )
-            )
-        }
+
+        handlePaymentIntentResponse()
+        assert(component.handleActivityResult(1007, RESULT_OK, intent))
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Failure(exception)) }
     }
 
     @Test
-    fun `test handleActivityResult when result code is OK without intent data`() {
-        handlePaymentIntentResponse()
-        component.handleActivityResult(991, RESULT_OK, null)
-        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Cancel) }
-    }
-
-    @Test
-    fun `test handleActivityResult when result code is OK with invalid intent data`() {
-        val mockResponseJson = "adfqrdasf"
-        val mockData = mockk<Intent>()
-        val paymentData = mockk<PaymentData>()
-        every { paymentData.toJson() } returns mockResponseJson
-        every { PaymentData.getFromIntent(mockData) } returns paymentData
+    fun `test handleActivityResult when result is google pay success`() {
+        val intent = mockk<Intent>()
+        val map = mockk<Map<String, Any>>()
+        every { intent.getExtraResult<GooglePayActivityLaunch.Result>() } returns GooglePayActivityLaunch.Result.Success(
+            map
+        )
 
         handlePaymentIntentResponse()
-        component.handleActivityResult(991, RESULT_OK, null)
-        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Cancel) }
+        assert(component.handleActivityResult(1007, RESULT_OK, intent))
+        verify(exactly = 1) { listener.onCompleted(AirwallexPaymentStatus.Success("id", map)) }
     }
 
     @Test

--- a/redirect/src/main/java/com/airwallex/android/redirect/RedirectComponent.kt
+++ b/redirect/src/main/java/com/airwallex/android/redirect/RedirectComponent.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.redirect
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.fragment.app.Fragment
 import com.airwallex.android.core.*
 import com.airwallex.android.core.exception.AirwallexCheckoutException
 import com.airwallex.android.core.extension.putIfNotNull
@@ -20,6 +21,7 @@ class RedirectComponent : ActionComponent {
     override fun handlePaymentIntentResponse(
         paymentIntentId: String,
         nextAction: NextAction?,
+        fragment: Fragment?,
         activity: Activity,
         applicationContext: Context,
         cardNextActionModel: CardNextActionModel?,

--- a/redirect/src/test/java/com/airwallex/android/redirect/RedirectComponentProviderTest.kt
+++ b/redirect/src/test/java/com/airwallex/android/redirect/RedirectComponentProviderTest.kt
@@ -67,6 +67,7 @@ class RedirectComponentProviderTest {
                     url = "https://cdn-psp.marmot-cloud.com/acwallet/alipayconnectcode?code=golcashier1629873426081sandbox&golSandbox=true&pspName=ALIPAY_CN",
                     method = "GET"
                 ),
+                null,
                 activity,
                 ApplicationProvider.getApplicationContext(),
                 null,

--- a/redirect/src/test/java/com/airwallex/android/redirect/RedirectComponentTest.kt
+++ b/redirect/src/test/java/com/airwallex/android/redirect/RedirectComponentTest.kt
@@ -57,6 +57,7 @@ class RedirectComponentTest {
                 url = testUrl,
                 method = null
             ),
+            null,
             activity,
             context,
             null,
@@ -80,6 +81,7 @@ class RedirectComponentTest {
                 url = testUrl,
                 method = null
             ),
+            null,
             activity,
             context,
             null,

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,8 +38,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartActivity.kt
@@ -76,11 +76,6 @@ class PaymentCartActivity : AppCompatActivity() {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        supportFragmentManager.fragments[0].onActivityResult(requestCode, resultCode, data)
-    }
-
     fun showAlert(title: String, message: String) {
         AlertDialog.Builder(this)
             .setTitle(title)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartActivity.kt
@@ -76,6 +76,11 @@ class PaymentCartActivity : AppCompatActivity() {
         }
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        supportFragmentManager.fragments[0].onActivityResult(requestCode, resultCode, data)
+    }
+
     fun showAlert(title: String, message: String) {
         AlertDialog.Builder(this)
             .setTitle(title)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -23,7 +23,6 @@ import com.airwallex.android.core.model.parser.PaymentIntentParser
 import com.airwallex.paymentacceptance.databinding.CartItemBinding
 import com.airwallex.paymentacceptance.databinding.FragmentCartBinding
 import kotlinx.coroutines.*
-import okhttp3.*
 import org.json.JSONObject
 import retrofit2.HttpException
 import java.math.BigDecimal
@@ -376,7 +375,7 @@ class PaymentCartFragment : Fragment() {
             if (directGooglePayCheckout) {
                 // Direct google pay flow
                 val session = buildSession(paymentIntent) as AirwallexPaymentSession
-                airwallex.confirmPaymentIntent(
+                airwallex.startGooglePay(
                     session = session,
                     listener = object : Airwallex.PaymentResultListener {
                         override fun onCompleted(status: AirwallexPaymentStatus) {

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -374,6 +374,7 @@ class PaymentCartFragment : Fragment() {
                 PaymentIntentParser().parse(JSONObject(paymentIntentResponse.string()))
             if (directGooglePayCheckout) {
                 // Direct google pay flow
+                (activity as? PaymentCartActivity)?.setLoadingProgress(true)
                 val session = buildSession(paymentIntent) as AirwallexPaymentSession
                 airwallex.startGooglePay(
                     session = session,
@@ -576,11 +577,12 @@ class PaymentCartFragment : Fragment() {
         super.onActivityResult(requestCode, resultCode, data)
 
         // We need to handle activity result
-        AirwallexStarter.handlePaymentData(requestCode, resultCode, data)
-
-        // If integrate by low-level API
         if (directGooglePayCheckout) {
+            // If integrate by low-level API
             airwallex.handlePaymentData(requestCode, resultCode, data)
+        } else {
+            // If integrate by entire Airwallex Native UI
+            AirwallexStarter.handlePaymentData(requestCode, resultCode, data)
         }
     }
 

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartViewModel.kt
@@ -49,7 +49,7 @@ internal class PaymentCartViewModel(
     internal class Factory(
         private val application: Application
     ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
             return PaymentCartViewModel(
                 application

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
@@ -147,6 +147,11 @@ class PaymentSettingsFragment :
             force3DSPref.setValueIndex(0)
         }
 
+        val googlePayCheckoutPref: ListPreference? = findPreference(getString(R.string.google_pay_checkout))
+        if (googlePayCheckoutPref != null && googlePayCheckoutPref.value == null) {
+            googlePayCheckoutPref.setValueIndex(0)
+        }
+
         val autoCapturePref: ListPreference? = findPreference(getString(R.string.auto_capture))
         if (autoCapturePref != null && autoCapturePref.value == null) {
             autoCapturePref.setValueIndex(0)
@@ -215,6 +220,7 @@ class PaymentSettingsFragment :
         onSharedPreferenceChanged(preferences, getString(R.string.requires_cvc))
         onSharedPreferenceChanged(preferences, getString(R.string.requires_email))
         onSharedPreferenceChanged(preferences, getString(R.string.force_3ds))
+        onSharedPreferenceChanged(preferences, getString(R.string.google_pay_checkout))
         onSharedPreferenceChanged(preferences, getString(R.string.auto_capture))
         registerOnSharedPreferenceChangeListener()
     }
@@ -267,6 +273,7 @@ class PaymentSettingsFragment :
             getString(R.string.next_trigger_by) -> preference?.summary = Settings.nextTriggerBy
             getString(R.string.requires_cvc) -> preference?.summary = Settings.requiresCVC
             getString(R.string.force_3ds) -> preference?.summary = Settings.force3DS
+            getString(R.string.google_pay_checkout) -> preference?.summary = Settings.directGooglePayCheckout
             getString(R.string.auto_capture) -> preference?.summary = Settings.autoCapture
             getString(R.string.requires_email) -> preference?.summary = Settings.requiresEmail
         }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentSettingsFragment.kt
@@ -147,6 +147,11 @@ class PaymentSettingsFragment :
             force3DSPref.setValueIndex(0)
         }
 
+        val cardCheckoutPref: ListPreference? = findPreference(getString(R.string.card_checkout))
+        if (cardCheckoutPref != null && cardCheckoutPref.value == null) {
+            cardCheckoutPref.setValueIndex(0)
+        }
+
         val googlePayCheckoutPref: ListPreference? = findPreference(getString(R.string.google_pay_checkout))
         if (googlePayCheckoutPref != null && googlePayCheckoutPref.value == null) {
             googlePayCheckoutPref.setValueIndex(0)
@@ -220,6 +225,7 @@ class PaymentSettingsFragment :
         onSharedPreferenceChanged(preferences, getString(R.string.requires_cvc))
         onSharedPreferenceChanged(preferences, getString(R.string.requires_email))
         onSharedPreferenceChanged(preferences, getString(R.string.force_3ds))
+        onSharedPreferenceChanged(preferences, getString(R.string.card_checkout))
         onSharedPreferenceChanged(preferences, getString(R.string.google_pay_checkout))
         onSharedPreferenceChanged(preferences, getString(R.string.auto_capture))
         registerOnSharedPreferenceChangeListener()
@@ -273,6 +279,7 @@ class PaymentSettingsFragment :
             getString(R.string.next_trigger_by) -> preference?.summary = Settings.nextTriggerBy
             getString(R.string.requires_cvc) -> preference?.summary = Settings.requiresCVC
             getString(R.string.force_3ds) -> preference?.summary = Settings.force3DS
+            getString(R.string.card_checkout) -> preference?.summary = Settings.directCardCheckout
             getString(R.string.google_pay_checkout) -> preference?.summary = Settings.directGooglePayCheckout
             getString(R.string.auto_capture) -> preference?.summary = Settings.autoCapture
             getString(R.string.requires_email) -> preference?.summary = Settings.requiresEmail

--- a/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
@@ -135,6 +135,17 @@ object Settings {
                 ?: defaultAutoCapture
         }
 
+    val directGooglePayCheckout: String
+        get() {
+            val defaultDirectGooglePayCheckout =
+                SampleApplication.instance.resources.getStringArray(R.array.array_google_pay_checkout)[1]
+            return sharedPreferences.getString(
+                context.getString(R.string.google_pay_checkout),
+                defaultDirectGooglePayCheckout
+            )
+                ?: defaultDirectGooglePayCheckout
+        }
+
     val apiKey: String
         get() {
             val value = sharedPreferences.getString(context.getString(R.string.api_key), getMetadata(METADATA_KEY_API_KEY))

--- a/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
@@ -135,6 +135,17 @@ object Settings {
                 ?: defaultAutoCapture
         }
 
+    val directCardCheckout: String
+        get() {
+            val defaultDirectCardCheckout =
+                SampleApplication.instance.resources.getStringArray(R.array.array_card_checkout)[1]
+            return sharedPreferences.getString(
+                context.getString(R.string.card_checkout),
+                defaultDirectCardCheckout
+            )
+                ?: defaultDirectCardCheckout
+        }
+
     val directGooglePayCheckout: String
         get() {
             val defaultDirectGooglePayCheckout =

--- a/sample/src/main/res/values/arrays.xml
+++ b/sample/src/main/res/values/arrays.xml
@@ -41,4 +41,9 @@
         <item>False</item>
         <item>True</item>
     </string-array>
+
+    <string-array name="array_card_checkout">
+        <item>False</item>
+        <item>True</item>
+    </string-array>
 </resources>

--- a/sample/src/main/res/values/arrays.xml
+++ b/sample/src/main/res/values/arrays.xml
@@ -36,4 +36,9 @@
         <item>Enabled</item>
         <item>Disabled</item>
     </string-array>
+
+    <string-array name="array_google_pay_checkout">
+        <item>False</item>
+        <item>True</item>
+    </string-array>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="requires_email">Requires Email</string>
     <string name="force_3ds">Force 3DS</string>
     <string name="auto_capture">Auto Capture</string>
+    <string name="google_pay_checkout">Direct Google Pay Checkout</string>
     <string name="shipping">Shipping</string>
     <string name="item">Item</string>
     <string name="total">Total</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="requires_email">Requires Email</string>
     <string name="force_3ds">Force 3DS</string>
     <string name="auto_capture">Auto Capture</string>
+    <string name="card_checkout">Direct Card Checkout</string>
     <string name="google_pay_checkout">Direct Google Pay Checkout</string>
     <string name="shipping">Shipping</string>
     <string name="item">Item</string>

--- a/sample/src/main/res/xml/settings.xml
+++ b/sample/src/main/res/xml/settings.xml
@@ -54,6 +54,13 @@
             android:key="@string/auto_capture"
             android:title="@string/auto_capture" />
 
+        <ListPreference
+            android:dialogTitle="@string/google_pay_checkout"
+            android:entries="@array/array_google_pay_checkout"
+            android:entryValues="@array/array_google_pay_checkout"
+            android:key="@string/google_pay_checkout"
+            android:title="@string/google_pay_checkout" />
+
         <EditTextPreference
             android:key="@string/return_url"
             android:title="@string/return_url" />

--- a/sample/src/main/res/xml/settings.xml
+++ b/sample/src/main/res/xml/settings.xml
@@ -55,6 +55,13 @@
             android:title="@string/auto_capture" />
 
         <ListPreference
+            android:dialogTitle="@string/card_checkout"
+            android:entries="@array/array_card_checkout"
+            android:entryValues="@array/array_card_checkout"
+            android:key="@string/card_checkout"
+            android:title="@string/card_checkout" />
+
+        <ListPreference
             android:dialogTitle="@string/google_pay_checkout"
             android:entries="@array/array_google_pay_checkout"
             android:entryValues="@array/array_google_pay_checkout"

--- a/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityManager.kt
+++ b/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityManager.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.threedsecurity
 import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import com.airwallex.android.core.*
 import com.airwallex.android.core.exception.AirwallexException
 import com.airwallex.android.core.extension.putIfNotNull
@@ -23,6 +24,7 @@ object ThreeDSecurityManager {
     fun handleThreeDSFlow(
         paymentIntentId: String,
         activity: Activity,
+        fragment: Fragment?,
         nextAction: NextAction,
         cardNextActionModel: CardNextActionModel,
         listener: Airwallex.PaymentResultListener,
@@ -54,7 +56,6 @@ object ThreeDSecurityManager {
                 }
             )
 
-            val fragment = cardNextActionModel.fragment
             val threeDSecurityActivityLaunch = if (fragment != null) {
                 ThreeDSecurityActivityLaunch(fragment)
             } else {
@@ -135,6 +136,7 @@ object ThreeDSecurityManager {
                                             handleThreeDSFlow(
                                                 paymentIntentId,
                                                 activity,
+                                                fragment,
                                                 continueNextAction,
                                                 cardNextActionModel,
                                                 listener,

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -87,6 +87,7 @@ sonarqube {
 
                 '**/*ViewModelFactory.*',
                 '**/*ScreenEvent.*',
+                '**/*ActivityLaunch.*',
                 '**/core/Airwallex.kt',
                 '**/card/AirwallexSecurityConnector.kt',
                 '**/AirwallexStarter.kt',

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -10,6 +10,16 @@
         <item name="colorControlActivated">@color/airwallex_tint_color</item>
     </style>
 
+    <style name="AirwallexTransparentTheme" parent="@style/Theme.MaterialComponents.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
     <style name="AirwallexProgressBarStyle">
         <item name="colorAccent">@color/airwallex_tint_color</item>
     </style>

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -10,7 +10,7 @@
         <item name="colorControlActivated">@color/airwallex_tint_color</item>
     </style>
 
-    <style name="AirwallexTransparentTheme" parent="@style/Theme.MaterialComponents.Light.NoActionBar">
+    <style name="AirwallexTransparentTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -18,6 +18,7 @@
         <item name="android:backgroundDimEnabled">true</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AirwallexProgressBarStyle">

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
@@ -3,6 +3,7 @@ package com.airwallex.android.wechat
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import androidx.fragment.app.Fragment
 import com.airwallex.android.core.*
 import com.airwallex.android.core.exception.AirwallexCheckoutException
 import com.airwallex.android.core.log.AnalyticsLogger
@@ -64,6 +65,7 @@ class WeChatComponent : ActionComponent {
     override fun handlePaymentIntentResponse(
         paymentIntentId: String,
         nextAction: NextAction?,
+        fragment: Fragment?,
         activity: Activity,
         applicationContext: Context,
         cardNextActionModel: CardNextActionModel?,

--- a/wechat/src/test/java/com/airwallex/wechat/WeChatComponentProviderTest.kt
+++ b/wechat/src/test/java/com/airwallex/wechat/WeChatComponentProviderTest.kt
@@ -75,6 +75,7 @@ class WeChatComponentProviderTest {
                 ),
                 dcc = null, url = null, method = null
             ),
+            null,
             activity,
             ApplicationProvider.getApplicationContext(),
             null,


### PR DESCRIPTION
This allows google pay direct integration by:
- Provide public interface method `startGooglePay` in `Airwallex`
- Create interim activity to launch Google Pay so that we can handle launching payment from either `Activity` or `Fragment`
- Add Google Pay & Card direct integration flow to sample App

Update:
- Target SDK version to 34 and Java to 17
- Google Pay Wallet Api to latest
- Kotlin version

Fix:
- Race condition when card and google pay try to compete to handle 3ds activity result (since both components have the handler)