### PR TITLE
[APAM-4] Skip payment methods list if pay by card only

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
@@ -166,11 +166,23 @@ internal class PaymentMethodsViewModel(
                 }
                 val retrieveMethods = async { retrieveAvailablePaymentMethods(clientSecret) }
                 try {
-                    Result.success(Pair(retrieveMethods.await(), retrieveConsents.await()))
+                    val methods = retrieveMethods.await()
+                    val consents = retrieveConsents.await()
+                    Result.success(Pair(filterPaymentMethodsBySession(methods, session.paymentMethods), consents))
                 } catch (exception: AirwallexException) {
                     Result.failure(exception)
                 }
             }
+        }
+    }
+
+    private fun filterPaymentMethodsBySession(
+        sourceList: List<AvailablePaymentMethodType>,
+        filterList: List<String>?
+    ): List<AvailablePaymentMethodType> {
+        if (filterList.isNullOrEmpty()) return sourceList
+        return filterList.mapNotNull { name ->
+            sourceList.find { it.name == name }
         }
     }
 

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsViewModel.kt
@@ -189,7 +189,7 @@ internal class PaymentMethodsViewModel(
     ): List<AvailablePaymentMethodType> {
         if (filterList.isNullOrEmpty()) return sourceList
         return filterList.mapNotNull { name ->
-            sourceList.find { it.name == name }
+            sourceList.find { it.name.equals(name, ignoreCase = true) }
         }
     }
 

--- a/airwallex/src/test/java/com/airwallex/android/view/PaymentMethodsViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/PaymentMethodsViewModelTest.kt
@@ -41,7 +41,6 @@ class PaymentMethodsViewModelTest {
             val viewModel = mockViewModel(transactionMode = TransactionMode.RECURRING)
             val result = viewModel.fetchAvailablePaymentMethodsAndConsents()?.getOrNull()
             assertEquals(result?.first?.first()?.name, "card")
-            assertEquals(result?.second?.first()?.paymentMethod?.card?.name, "John")
             verify(exactly = 1) { TokenManager.updateClientSecret(any()) }
         }
 

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -294,7 +294,7 @@ class Airwallex internal constructor(
                 pageSize = params.pageSize,
                 active = params.active,
                 transactionCurrency = params.transactionCurrency,
-                transactionMode = params.transactionMode,
+                transactionMode = transactionMode,
                 countryCode = params.countryCode
             )
         )

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
@@ -64,7 +64,8 @@ class AirwallexPaymentSession internal constructor(
     override val googlePayOptions: GooglePayOptions? = null,
 
     /**
-     * limit the payment methods displayed on the list screen
+     * An array of payment method type names to limit the payment methods displayed on the list screen. Only available ones from your Airwallex account will be applied, any other ones will be ignored. Also the order of payment method list will follow the order of this array.
+     * API reference: https://www.airwallex.com/docs/api#/Payment_Acceptance/Config/_api_v1_pa_config_payment_method_types/get JSON Object field: items.name
      */
     override val paymentMethods: List<String>? = null,
 

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
@@ -114,7 +114,7 @@ class AirwallexPaymentSession internal constructor(
             this.hidePaymentConsents = hidePaymentConsents
         }
 
-        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+        fun setPaymentMethods(paymentMethods: List<String>?): Builder = apply {
             this.paymentMethods = paymentMethods
         }
 

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
@@ -67,7 +67,13 @@ class AirwallexPaymentSession internal constructor(
      * Indicate if the payment shall be captured immediately after authorized. Only applicable to Card.
      * Default: true
      */
-    val autoCapture: Boolean = true
+    val autoCapture: Boolean = true,
+
+    /**
+     *  control whether saved cards are displayed on the list screen
+     */
+    val hidePaymentConsents: Boolean = false
+
 ) : AirwallexSession(), Parcelable {
 
     class Builder(
@@ -80,6 +86,7 @@ class AirwallexPaymentSession internal constructor(
         private var isEmailRequired: Boolean = false
         private var returnUrl: String? = null
         private var autoCapture: Boolean = true
+        private var hidePaymentConsents: Boolean = false
 
         fun setRequireBillingInformation(requiresBillingInformation: Boolean): Builder = apply {
             this.isBillingInformationRequired = requiresBillingInformation
@@ -97,6 +104,10 @@ class AirwallexPaymentSession internal constructor(
             this.autoCapture = autoCapture
         }
 
+        fun setHidePaymentConsents(hidePaymentConsents: Boolean): Builder = apply {
+            this.hidePaymentConsents = hidePaymentConsents
+        }
+
         override fun build(): AirwallexPaymentSession {
             return AirwallexPaymentSession(
                 paymentIntent = paymentIntent,
@@ -109,7 +120,8 @@ class AirwallexPaymentSession internal constructor(
                 customerId = paymentIntent.customerId,
                 returnUrl = returnUrl,
                 googlePayOptions = googlePayOptions,
-                autoCapture = autoCapture
+                autoCapture = autoCapture,
+                hidePaymentConsents = hidePaymentConsents
             )
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
@@ -64,6 +64,11 @@ class AirwallexPaymentSession internal constructor(
     override val googlePayOptions: GooglePayOptions? = null,
 
     /**
+     * limit the payment methods displayed on the list screen
+     */
+    override val paymentMethods: List<String>? = null,
+
+    /**
      * Indicate if the payment shall be captured immediately after authorized. Only applicable to Card.
      * Default: true
      */
@@ -87,6 +92,7 @@ class AirwallexPaymentSession internal constructor(
         private var returnUrl: String? = null
         private var autoCapture: Boolean = true
         private var hidePaymentConsents: Boolean = false
+        private var paymentMethods: List<String>? = null
 
         fun setRequireBillingInformation(requiresBillingInformation: Boolean): Builder = apply {
             this.isBillingInformationRequired = requiresBillingInformation
@@ -108,6 +114,10 @@ class AirwallexPaymentSession internal constructor(
             this.hidePaymentConsents = hidePaymentConsents
         }
 
+        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+            this.paymentMethods = paymentMethods
+        }
+
         override fun build(): AirwallexPaymentSession {
             return AirwallexPaymentSession(
                 paymentIntent = paymentIntent,
@@ -121,7 +131,8 @@ class AirwallexPaymentSession internal constructor(
                 returnUrl = returnUrl,
                 googlePayOptions = googlePayOptions,
                 autoCapture = autoCapture,
-                hidePaymentConsents = hidePaymentConsents
+                hidePaymentConsents = hidePaymentConsents,
+                paymentMethods = paymentMethods
             )
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
@@ -76,7 +76,8 @@ class AirwallexRecurringSession internal constructor(
     override val googlePayOptions: GooglePayOptions? = null,
 
     /**
-     * limit the payment methods displayed on the list screen
+     * An array of payment method type names to limit the payment methods displayed on the list screen. Only available ones from your Airwallex account will be applied, any other ones will be ignored. Also the order of payment method list will follow the order of this array.
+     * API reference: https://www.airwallex.com/docs/api#/Payment_Acceptance/Config/_api_v1_pa_config_payment_method_types/get JSON Object field: items.name
      */
     override val paymentMethods: List<String>? = null,
 ) : AirwallexSession(), Parcelable {

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
@@ -73,7 +73,12 @@ class AirwallexRecurringSession internal constructor(
     /**
      * Google Pay options
      */
-    override val googlePayOptions: GooglePayOptions? = null
+    override val googlePayOptions: GooglePayOptions? = null,
+
+    /**
+     * limit the payment methods displayed on the list screen
+     */
+    override val paymentMethods: List<String>? = null,
 ) : AirwallexSession(), Parcelable {
 
     class Builder(
@@ -91,6 +96,7 @@ class AirwallexRecurringSession internal constructor(
         private var merchantTriggerReason: PaymentConsent.MerchantTriggerReason =
             PaymentConsent.MerchantTriggerReason.UNSCHEDULED
         private var returnUrl: String? = null
+        private var paymentMethods: List<String>? = null
 
         fun setShipping(shipping: Shipping?): Builder = apply {
             this.shipping = shipping
@@ -117,6 +123,10 @@ class AirwallexRecurringSession internal constructor(
             this.returnUrl = returnUrl
         }
 
+        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+            this.paymentMethods = paymentMethods
+        }
+
         override fun build(): AirwallexRecurringSession {
             return AirwallexRecurringSession(
                 nextTriggerBy = nextTriggerBy,
@@ -129,7 +139,8 @@ class AirwallexRecurringSession internal constructor(
                 isBillingInformationRequired = isBillingInformationRequired,
                 isEmailRequired = isEmailRequired,
                 customerId = customerId,
-                returnUrl = returnUrl
+                returnUrl = returnUrl,
+                paymentMethods = paymentMethods
             )
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringSession.kt
@@ -123,7 +123,7 @@ class AirwallexRecurringSession internal constructor(
             this.returnUrl = returnUrl
         }
 
-        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+        fun setPaymentMethods(paymentMethods: List<String>?): Builder = apply {
             this.paymentMethods = paymentMethods
         }
 

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
@@ -83,7 +83,8 @@ class AirwallexRecurringWithIntentSession internal constructor(
     override val googlePayOptions: GooglePayOptions? = null,
 
     /**
-     * limit the payment methods displayed on the list screen
+     * An array of payment method type names to limit the payment methods displayed on the list screen. Only available ones from your Airwallex account will be applied, any other ones will be ignored. Also the order of payment method list will follow the order of this array.
+     * API reference: https://www.airwallex.com/docs/api#/Payment_Acceptance/Config/_api_v1_pa_config_payment_method_types/get JSON Object field: items.name
      */
     override val paymentMethods: List<String>? = null,
 

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
@@ -135,7 +135,7 @@ class AirwallexRecurringWithIntentSession internal constructor(
             this.autoCapture = autoCapture
         }
 
-        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+        fun setPaymentMethods(paymentMethods: List<String>?): Builder = apply {
             this.paymentMethods = paymentMethods
         }
 

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
@@ -83,6 +83,11 @@ class AirwallexRecurringWithIntentSession internal constructor(
     override val googlePayOptions: GooglePayOptions? = null,
 
     /**
+     * limit the payment methods displayed on the list screen
+     */
+    override val paymentMethods: List<String>? = null,
+
+    /**
      * Indicate if the payment shall be captured immediately after authorized. Only applicable to Card.
      * Default: true
      */
@@ -103,6 +108,7 @@ class AirwallexRecurringWithIntentSession internal constructor(
             PaymentConsent.MerchantTriggerReason.UNSCHEDULED
         private var returnUrl: String? = null
         private var autoCapture: Boolean = true
+        private var paymentMethods: List<String>? = null
 
         fun setRequireBillingInformation(requiresBillingInformation: Boolean): Builder = apply {
             this.isBillingInformationRequired = requiresBillingInformation
@@ -129,6 +135,10 @@ class AirwallexRecurringWithIntentSession internal constructor(
             this.autoCapture = autoCapture
         }
 
+        fun sePaymentMethods(paymentMethods: List<String>?): Builder = apply {
+            this.paymentMethods = paymentMethods
+        }
+
         override fun build(): AirwallexRecurringWithIntentSession {
             if (paymentIntent.customerId == null) {
                 throw Exception("Customer id is required if the PaymentIntent is created for recurring payment.")
@@ -145,7 +155,8 @@ class AirwallexRecurringWithIntentSession internal constructor(
                 isBillingInformationRequired = isBillingInformationRequired,
                 isEmailRequired = isEmailRequired,
                 returnUrl = returnUrl,
-                autoCapture = autoCapture
+                autoCapture = autoCapture,
+                paymentMethods = paymentMethods
             )
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexSession.kt
@@ -52,7 +52,8 @@ abstract class AirwallexSession : Parcelable {
     abstract val googlePayOptions: GooglePayOptions?
 
     /**
-     * limit the payment methods displayed on the list screen
+     * An array of payment method type names to limit the payment methods displayed on the list screen. Only available ones from your Airwallex account will be applied, any other ones will be ignored. Also the order of payment method list will follow the order of this array.
+     * API reference: https://www.airwallex.com/docs/api#/Payment_Acceptance/Config/_api_v1_pa_config_payment_method_types/get JSON Object field: items.name
      */
     abstract val paymentMethods: List<String>?
 }

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexSession.kt
@@ -50,4 +50,9 @@ abstract class AirwallexSession : Parcelable {
      * Google Pay options
      */
     abstract val googlePayOptions: GooglePayOptions?
+
+    /**
+     * limit the payment methods displayed on the list screen
+     */
+    abstract val paymentMethods: List<String>?
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentSessionTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentSessionTest.kt
@@ -16,6 +16,10 @@ class AirwallexPaymentSessionTest {
         )
             .setRequireBillingInformation(false)
             .setRequireEmail(true)
+            .setReturnUrl("airwallexcheckout://com.airwallex.paymentacceptance")
+            .setPaymentMethods(listOf("googlepay"))
+            .setHidePaymentConsents(false)
+            .setAutoCapture(false)
             .build()
 
         assertNotNull(airwallexPaymentSession)
@@ -34,5 +38,9 @@ class AirwallexPaymentSessionTest {
         assertEquals(null, airwallexPaymentSession.shipping)
 
         assertEquals("cus_ps8e0ZgQzd2QnCxVpzJrHD6KOVu", airwallexPaymentSession.customerId)
+        assertEquals("airwallexcheckout://com.airwallex.paymentacceptance", airwallexPaymentSession.returnUrl)
+        assertEquals(false, airwallexPaymentSession.autoCapture)
+        assertEquals(false, airwallexPaymentSession.hidePaymentConsents)
+        assertNotNull(airwallexPaymentSession.paymentMethods)
     }
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringSessionTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringSessionTest.kt
@@ -22,6 +22,8 @@ class AirwallexRecurringSessionTest {
             .setRequireBillingInformation(false)
             .setRequireCvc(true)
             .setRequireEmail(true)
+            .setReturnUrl("airwallexcheckout://com.airwallex.paymentacceptance")
+            .setPaymentMethods(listOf("googlepay"))
             .build()
 
         assertNotNull(airwallexRecurringSession)
@@ -47,5 +49,8 @@ class AirwallexRecurringSessionTest {
 
         assertNotNull(airwallexRecurringSession.customerId)
         assertEquals("cus_ps8e0ZgQzd2QnCxVpzJrHD6KOVu", airwallexRecurringSession.customerId)
+
+        assertEquals("airwallexcheckout://com.airwallex.paymentacceptance", airwallexRecurringSession.returnUrl)
+        assertNotNull(airwallexRecurringSession.paymentMethods)
     }
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringWithIntentSessionTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringWithIntentSessionTest.kt
@@ -22,6 +22,9 @@ class AirwallexRecurringWithIntentSessionTest {
             .setRequireBillingInformation(false)
             .setRequireCvc(true)
             .setRequireEmail(true)
+            .setReturnUrl("airwallexcheckout://com.airwallex.paymentacceptance")
+            .setAutoCapture(false)
+            .setPaymentMethods(listOf("googlepay"))
             .build()
 
         assertNotNull(airwallexRecurringWithIntentSession)
@@ -50,5 +53,9 @@ class AirwallexRecurringWithIntentSessionTest {
 
         assertNotNull(airwallexRecurringWithIntentSession.customerId)
         assertEquals("cus_ps8e0ZgQzd2QnCxVpzJrHD6KOVu", airwallexRecurringWithIntentSession.customerId)
+
+        assertEquals("airwallexcheckout://com.airwallex.paymentacceptance", airwallexRecurringWithIntentSession.returnUrl)
+        assertEquals(false, airwallexRecurringWithIntentSession.autoCapture)
+        assertNotNull(airwallexRecurringWithIntentSession.paymentMethods)
     }
 }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -389,7 +389,7 @@ class PaymentCartFragment : Fragment() {
                 //use hidePaymentConsents boolean to control whether saved cards are displayed on the list screen
                 hidePaymentConsents = false,
                 //limit the payment methods displayed on the list screen
-                // paymentMethods = listOf("fps", "card", "googlepay", "paypal", "alipayhk")
+//                 paymentMethods = listOf("card", "Googlepay", "paypal", "alipayhk","fps")
             )
             if (directCardCheckout) {
                 // Direct payment flow with provided card details

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -1,7 +1,6 @@
 package com.airwallex.paymentacceptance
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
 import android.util.AttributeSet
@@ -13,7 +12,6 @@ import android.widget.RelativeLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import com.airwallex.android.AirwallexStarter
 import com.airwallex.android.core.*
 import com.airwallex.android.core.exception.AirwallexException
 import com.airwallex.android.core.extension.setOnSingleClickListener
@@ -185,7 +183,7 @@ class PaymentCartFragment : Fragment() {
                     .setReturnUrl(Settings.returnUrl)
                     .setAutoCapture(autoCapture)
                     .setHidePaymentConsents(hidePaymentConsents)
-                    .sePaymentMethods(paymentMethods)
+                    .setPaymentMethods(paymentMethods)
                     .build()
             }
 
@@ -202,7 +200,7 @@ class PaymentCartFragment : Fragment() {
                     .setRequireCvc(requiresCVC)
                     .setMerchantTriggerReason(if (nextTriggerBy == PaymentConsent.NextTriggeredBy.MERCHANT) PaymentConsent.MerchantTriggerReason.SCHEDULED else PaymentConsent.MerchantTriggerReason.UNSCHEDULED)
                     .setReturnUrl(Settings.returnUrl)
-                    .sePaymentMethods(paymentMethods)
+                    .setPaymentMethods(paymentMethods)
                     .build()
             }
 
@@ -224,7 +222,7 @@ class PaymentCartFragment : Fragment() {
                     .setMerchantTriggerReason(if (nextTriggerBy == PaymentConsent.NextTriggeredBy.MERCHANT) PaymentConsent.MerchantTriggerReason.SCHEDULED else PaymentConsent.MerchantTriggerReason.UNSCHEDULED)
                     .setReturnUrl(Settings.returnUrl)
                     .setAutoCapture(autoCapture)
-                    .sePaymentMethods(paymentMethods)
+                    .setPaymentMethods(paymentMethods)
                     .build()
             }
         }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -165,7 +165,8 @@ class PaymentCartFragment : Fragment() {
     private fun buildSession(
         paymentIntent: PaymentIntent? = null,
         customerId: String? = null,
-        hidePaymentConsents: Boolean = false
+        hidePaymentConsents: Boolean = false,
+        paymentMethods: List<String>? = null
     ): AirwallexSession {
         return when (checkoutMode) {
             AirwallexCheckoutMode.PAYMENT -> {
@@ -184,6 +185,7 @@ class PaymentCartFragment : Fragment() {
                     .setReturnUrl(Settings.returnUrl)
                     .setAutoCapture(autoCapture)
                     .setHidePaymentConsents(hidePaymentConsents)
+                    .sePaymentMethods(paymentMethods)
                     .build()
             }
 
@@ -200,6 +202,7 @@ class PaymentCartFragment : Fragment() {
                     .setRequireCvc(requiresCVC)
                     .setMerchantTriggerReason(if (nextTriggerBy == PaymentConsent.NextTriggeredBy.MERCHANT) PaymentConsent.MerchantTriggerReason.SCHEDULED else PaymentConsent.MerchantTriggerReason.UNSCHEDULED)
                     .setReturnUrl(Settings.returnUrl)
+                    .sePaymentMethods(paymentMethods)
                     .build()
             }
 
@@ -221,6 +224,7 @@ class PaymentCartFragment : Fragment() {
                     .setMerchantTriggerReason(if (nextTriggerBy == PaymentConsent.NextTriggeredBy.MERCHANT) PaymentConsent.MerchantTriggerReason.SCHEDULED else PaymentConsent.MerchantTriggerReason.UNSCHEDULED)
                     .setReturnUrl(Settings.returnUrl)
                     .setAutoCapture(autoCapture)
+                    .sePaymentMethods(paymentMethods)
                     .build()
             }
         }
@@ -382,7 +386,13 @@ class PaymentCartFragment : Fragment() {
 
             val paymentIntent =
                 PaymentIntentParser().parse(JSONObject(paymentIntentResponse.string()))
-            val session = buildSession(paymentIntent, hidePaymentConsents = false)//use hidePaymentConsents boolean to control whether saved cards are displayed on the list screen
+            val session = buildSession(
+                paymentIntent,
+                //use hidePaymentConsents boolean to control whether saved cards are displayed on the list screen
+                hidePaymentConsents = false,
+                //limit the payment methods displayed on the list screen
+                // paymentMethods = listOf("fps", "card", "googlepay", "paypal", "alipayhk")
+            )
             if (directCardCheckout) {
                 // Direct payment flow with provided card details
                 (activity as? PaymentCartActivity)?.setLoadingProgress(true)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/PaymentCartFragment.kt
@@ -164,7 +164,8 @@ class PaymentCartFragment : Fragment() {
 
     private fun buildSession(
         paymentIntent: PaymentIntent? = null,
-        customerId: String? = null
+        customerId: String? = null,
+        hidePaymentConsents: Boolean = false
     ): AirwallexSession {
         return when (checkoutMode) {
             AirwallexCheckoutMode.PAYMENT -> {
@@ -182,6 +183,7 @@ class PaymentCartFragment : Fragment() {
                     .setRequireEmail(requiresEmail)
                     .setReturnUrl(Settings.returnUrl)
                     .setAutoCapture(autoCapture)
+                    .setHidePaymentConsents(hidePaymentConsents)
                     .build()
             }
 
@@ -380,7 +382,7 @@ class PaymentCartFragment : Fragment() {
 
             val paymentIntent =
                 PaymentIntentParser().parse(JSONObject(paymentIntentResponse.string()))
-            val session = buildSession(paymentIntent)
+            val session = buildSession(paymentIntent, hidePaymentConsents = false)//use hidePaymentConsents boolean to control whether saved cards are displayed on the list screen
             if (directCardCheckout) {
                 // Direct payment flow with provided card details
                 (activity as? PaymentCartActivity)?.setLoadingProgress(true)


### PR DESCRIPTION
Integration requirements:

Merchant can use paymentMethods array to limit the payment methods displayed on the list screen

Merchant can use hidePaymentConsents boolean to control whether saved cards are displayed on the list screen

UI requirements:

Payment method list screen will be skipped and user is directed to the card payment screen if merchant limits the payment method as card only