### PR TITLE
[APAM-40] Correlate risk session id to device data

### DIFF
--- a/card/src/main/java/com/airwallex/android/card/CardComponent.kt
+++ b/card/src/main/java/com/airwallex/android/card/CardComponent.kt
@@ -79,12 +79,12 @@ class CardComponent : ActionComponent {
     }
 
     override fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     ) {
         AirwallexSecurityConnector().retrieveSecurityToken(
-            paymentIntentId,
+            sessionId,
             applicationContext,
             securityTokenListener
         )

--- a/components-core/build.gradle
+++ b/components-core/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.2"
     implementation "io.github.airwallex:AirTracker:1.0.3"
-    api "io.github.airwallex:RiskSdk:1.0.6"
+    api "io.github.airwallex:RiskSdk:1.0.8"
 
     // test
     testImplementation 'org.json:json:20231013'

--- a/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/ActionComponent.kt
@@ -30,7 +30,7 @@ interface ActionComponent {
     ): Boolean
 
     fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     )

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -843,7 +843,7 @@ class Airwallex internal constructor(
                     return
                 }
                 provider.get().retrieveSecurityToken(
-                    params.paymentIntentId, applicationContext,
+                    AirwallexRisk.sessionId.toString(), applicationContext,
                     object : SecurityTokenListener {
                         override fun onResponse(deviceId: String) {
                             val device = paymentManager.buildDeviceInfo(deviceId)
@@ -1238,8 +1238,9 @@ class Airwallex internal constructor(
                 applicationContext = application,
                 accountId = null,
                 configuration = RiskConfiguration(
-                    isProduction = configuration.environment == Environment.PRODUCTION,
-                    tenant = Tenant.PA
+                    environment = configuration.environment.riskEnvironment,
+                    tenant = Tenant.PA,
+                    bufferTimeMillis = 5_000L
                 )
             )
         }

--- a/components-core/src/main/java/com/airwallex/android/core/Environment.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Environment.kt
@@ -26,4 +26,11 @@ enum class Environment(val value: String) {
             PRODUCTION -> "https://pci-api.airwallex.com/api/v1/checkout/elements/3ds?origin=https://checkout.airwallex.com"
         }
     }
+
+    val riskEnvironment: com.airwallex.risk.Environment
+        get() = when (this) {
+            STAGING -> com.airwallex.risk.Environment.STAGING
+            DEMO -> com.airwallex.risk.Environment.DEMO
+            PRODUCTION -> com.airwallex.risk.Environment.PRODUCTION
+        }
 }

--- a/components-core/src/main/java/com/airwallex/android/core/SecurityConnector.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/SecurityConnector.kt
@@ -8,7 +8,7 @@ import android.content.Context
 interface SecurityConnector {
 
     fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     )

--- a/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/extension/ActionComponentProvider+Extensions.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import com.airwallex.android.core.*
 import com.airwallex.android.core.exception.AirwallexException
 import com.airwallex.android.core.model.*
+import com.airwallex.risk.AirwallexRisk
 import java.util.*
 
 @Suppress("LongParameterList")
@@ -22,7 +23,7 @@ internal fun ActionComponent.confirmGooglePayIntent(
     listener: Airwallex.PaymentResultListener
 ) {
     retrieveSecurityToken(
-        paymentIntentId, applicationContext,
+        AirwallexRisk.sessionId.toString(), applicationContext,
         object : SecurityTokenListener {
             @Suppress("LongMethod")
             override fun onResponse(deviceId: String) {

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPluginsTest.kt
@@ -67,7 +67,7 @@ class AirwallexPluginsTest {
         }
 
         override fun retrieveSecurityToken(
-            paymentIntentId: String,
+            sessionId: String,
             applicationContext: Context,
             securityTokenListener: SecurityTokenListener
         ) {

--- a/components-core/src/test/java/com/airwallex/android/core/EnvironmentTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/EnvironmentTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertNotNull
 class EnvironmentTest {
 
     @Test
-    fun baseUrlTest() {
+    fun testBaseUrl() {
         assertNotNull(Environment.STAGING.baseUrl())
         assertEquals("https://api-staging.airwallex.com", Environment.STAGING.baseUrl())
 
@@ -19,7 +19,7 @@ class EnvironmentTest {
     }
 
     @Test
-    fun trackerUrl() {
+    fun testTrackerUrl() {
         assertNotNull(Environment.STAGING.trackerUrl())
         assertEquals("https://api-staging.airwallex.com/api/v1/checkout", Environment.STAGING.trackerUrl())
 
@@ -28,5 +28,12 @@ class EnvironmentTest {
 
         assertNotNull(Environment.PRODUCTION.trackerUrl())
         assertEquals("https://api.airwallex.com/api/v1/checkout", Environment.PRODUCTION.trackerUrl())
+    }
+
+    @Test
+    fun testRiskEnvironment() {
+        assertEquals(Environment.STAGING.riskEnvironment, com.airwallex.risk.Environment.STAGING)
+        assertEquals(Environment.DEMO.riskEnvironment, com.airwallex.risk.Environment.DEMO)
+        assertEquals(Environment.PRODUCTION.riskEnvironment, com.airwallex.risk.Environment.PRODUCTION)
     }
 }

--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayComponent.kt
@@ -128,12 +128,12 @@ class GooglePayComponent : ActionComponent {
     }
 
     override fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     ) {
         AirwallexSecurityConnector().retrieveSecurityToken(
-            paymentIntentId,
+            sessionId,
             applicationContext,
             securityTokenListener
         )

--- a/redirect/src/main/java/com/airwallex/android/redirect/RedirectComponent.kt
+++ b/redirect/src/main/java/com/airwallex/android/redirect/RedirectComponent.kt
@@ -78,7 +78,7 @@ class RedirectComponent : ActionComponent {
     }
 
     override fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     ) {

--- a/security-3ds/src/main/java/com/airwallex/android/threedsecurity/AirwallexSecurityConnector.kt
+++ b/security-3ds/src/main/java/com/airwallex/android/threedsecurity/AirwallexSecurityConnector.kt
@@ -20,14 +20,14 @@ class AirwallexSecurityConnector : SecurityConnector {
     private var profilingHandle: TMXProfilingHandle? = null
 
     /**
-     *  Retrieve the SecurityToken from Cardinals under the ID of [PaymentIntent]
+     *  Retrieve the SecurityToken from Cardinals under the ID of Airwallex session
      *
-     *  @param paymentIntentId ID of [PaymentIntent]
+     *  @param sessionId ID of an Airwallex session
      *  @param applicationContext The Context of Application
      *  @param securityTokenListener The listener of when retrieved the SecurityToken
      */
     override fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     ) {
@@ -41,16 +41,14 @@ class AirwallexSecurityConnector : SecurityConnector {
         getInstance().init(config)
 
         AirwallexLogger.debug("Successfully init init-ed")
-        doProfile(paymentIntentId, securityTokenListener)
+        doProfile(sessionId, securityTokenListener)
     }
 
     /**
      * Init was successful or there is a valid instance to be used for further calls. Fire a profile request
      */
-    private fun doProfile(paymentIntentId: String, securityTokenListener: SecurityTokenListener) {
-        val fraudSessionId = "$paymentIntentId${System.currentTimeMillis()}"
-        val sessionID = "${BuildConfig.DEVICE_FINGERPRINT_MERCHANT_ID}$fraudSessionId"
-        val options = TMXProfilingOptions().setSessionID(sessionID)
+    private fun doProfile(sessionId: String, securityTokenListener: SecurityTokenListener) {
+        val options = TMXProfilingOptions().setSessionID(sessionId)
         // Fire off the profiling request.
         profilingHandle = getInstance().profile(options) { result ->
             AirwallexLogger.debug(
@@ -59,11 +57,7 @@ class AirwallexSecurityConnector : SecurityConnector {
             profilingHandle?.cancel()
             profilingHandle = null
         }
-        AirwallexLogger.debug("Response sessionID $sessionID")
-        securityTokenListener.onResponse(sessionID)
-    }
-
-    companion object {
-        private const val TAG = "TrustDefender"
+        AirwallexLogger.debug("Response sessionID $sessionId")
+        securityTokenListener.onResponse(sessionId)
     }
 }

--- a/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
+++ b/wechat/src/main/java/com/airwallex/android/wechat/WeChatComponent.kt
@@ -144,7 +144,7 @@ class WeChatComponent : ActionComponent {
     }
 
     override fun retrieveSecurityToken(
-        paymentIntentId: String,
+        sessionId: String,
         applicationContext: Context,
         securityTokenListener: SecurityTokenListener
     ) {


### PR DESCRIPTION
- Update risk SDK and set time buffer as 5s
- Pass risk session ID to signifyd and `device data` in confirm intent request