### PR TITLE
[APAM-70] risk sdk not recording open events

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/util/ExpiryDateUtils.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/util/ExpiryDateUtils.kt
@@ -27,7 +27,11 @@ object ExpiryDateUtils {
     }
 
     internal fun isExpiryDateValid(expiryMonth: Int, expiryYear: Int): Boolean {
-        return isExpiryDateValid(expiryMonth, expiryYear, Calendar.getInstance())
+        return isExpiryDateValid(
+            expiryMonth,
+            expiryYear,
+            Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        )
     }
 
     internal fun isExpiryDateValid(expiryMonth: Int, expiryYear: Int, calendar: Calendar): Boolean {

--- a/airwallex/src/test/java/com/airwallex/android/view/ExpiryDateUtilsTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/ExpiryDateUtilsTest.kt
@@ -10,7 +10,7 @@ class ExpiryDateUtilsTest {
 
     @Test
     fun isExpiryDataValidTest() {
-        val calendar = Calendar.getInstance()
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
         calendar.set(Calendar.YEAR, 2018)
         calendar.set(Calendar.MONTH, Calendar.JANUARY)
 

--- a/components-core/build.gradle
+++ b/components-core/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.8.2"
     implementation "io.github.airwallex:AirTracker:1.0.3"
-    api "io.github.airwallex:RiskSdk:1.0.8"
+    api "io.github.airwallex:RiskSdk:1.0.9"
 
     // test
     testImplementation 'org.json:json:20231013'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -42,6 +42,10 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
     defaultConfig {
         applicationId "com.airwallex.paymentacceptance"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -42,10 +42,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     defaultConfig {
         applicationId "com.airwallex.paymentacceptance"
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
fix two issues：
1.fix the issue where the risk SDK does not record open events.
2.apply UTC calendar to expiry date of card