### PR TITLE
[APAM-227] Fix email not prefilled in payment and paymentWithIntent sessions

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodViewModel.kt
@@ -12,7 +12,6 @@ import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentSession
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexRecurringSession
-import com.airwallex.android.core.AirwallexRecurringWithIntentSession
 import com.airwallex.android.core.AirwallexSession
 import com.airwallex.android.core.CardBrand
 import com.airwallex.android.core.model.Billing
@@ -38,21 +37,7 @@ internal class AddPaymentMethodViewModel(
     }
 
     val shipping: Shipping? by lazy {
-        when (session) {
-            is AirwallexPaymentSession -> {
-                session.paymentIntent.order?.shipping
-            }
-
-            is AirwallexRecurringWithIntentSession -> {
-                session.paymentIntent.order?.shipping
-            }
-
-            is AirwallexRecurringSession -> {
-                session.shipping
-            }
-
-            else -> null
-        }
+        session.shipping
     }
 
     val canSaveCard: Boolean by lazy { session is AirwallexPaymentSession && session.customerId != null }

--- a/airwallex/src/test/java/com/airwallex/android/view/AddPaymentMethodViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/AddPaymentMethodViewModelTest.kt
@@ -22,11 +22,8 @@ class AddPaymentMethodViewModelTest {
     @Test
     fun `test shipping for AirwallexPaymentSession`() {
         val mockShipping = mockk<Shipping>(relaxed = true)
-        val mockPaymentIntent = mockk<PaymentIntent> {
-            every { order?.shipping } returns mockShipping
-        }
         val mockSession = mockk<AirwallexPaymentSession> {
-            every { paymentIntent } returns mockPaymentIntent
+            every { shipping } returns mockShipping
         }
         val viewModel = createViewModel(mockSession)
         assertEquals(mockShipping, viewModel.shipping)
@@ -35,11 +32,8 @@ class AddPaymentMethodViewModelTest {
     @Test
     fun `test shipping for AirwallexRecurringWithIntentSession`() {
         val mockShipping = mockk<Shipping>(relaxed = true)
-        val mockPaymentIntent = mockk<PaymentIntent> {
-            every { order?.shipping } returns mockShipping
-        }
         val mockSession = mockk<AirwallexRecurringWithIntentSession> {
-            every { paymentIntent } returns mockPaymentIntent
+            every { shipping } returns mockShipping
         }
         val viewModel = createViewModel(mockSession)
         assertEquals(mockShipping, viewModel.shipping)

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexPaymentSession.kt
@@ -94,6 +94,7 @@ class AirwallexPaymentSession internal constructor(
         private var autoCapture: Boolean = true
         private var hidePaymentConsents: Boolean = false
         private var paymentMethods: List<String>? = null
+        private var shipping: Shipping? = null
 
         init {
             paymentIntent.clientSecret?.apply {
@@ -125,13 +126,17 @@ class AirwallexPaymentSession internal constructor(
             this.paymentMethods = paymentMethods
         }
 
+        fun setShipping(shipping: Shipping?): Builder = apply {
+            this.shipping = shipping
+        }
+
         override fun build(): AirwallexPaymentSession {
             return AirwallexPaymentSession(
                 paymentIntent = paymentIntent,
                 currency = paymentIntent.currency,
                 countryCode = countryCode,
                 amount = paymentIntent.amount,
-                shipping = paymentIntent.order?.shipping,
+                shipping = shipping,
                 isBillingInformationRequired = isBillingInformationRequired,
                 isEmailRequired = isEmailRequired,
                 customerId = paymentIntent.customerId,

--- a/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/AirwallexRecurringWithIntentSession.kt
@@ -111,6 +111,7 @@ class AirwallexRecurringWithIntentSession internal constructor(
         private var autoCapture: Boolean = true
         private var paymentMethods: List<String>? = null
         private var googlePayOptions: GooglePayOptions? = null
+        private var shipping: Shipping? = null
 
         init {
             paymentIntent.clientSecret?.apply {
@@ -151,6 +152,10 @@ class AirwallexRecurringWithIntentSession internal constructor(
             this.googlePayOptions = googlePayOptions
         }
 
+        fun setShipping(shipping: Shipping?): Builder = apply {
+            this.shipping = shipping
+        }
+
         override fun build(): AirwallexRecurringWithIntentSession {
             if (paymentIntent.customerId == null) {
                 throw Exception("Customer id is required if the PaymentIntent is created for recurring payment.")
@@ -163,7 +168,7 @@ class AirwallexRecurringWithIntentSession internal constructor(
                 currency = paymentIntent.currency,
                 countryCode = countryCode,
                 amount = paymentIntent.amount,
-                shipping = paymentIntent.order?.shipping,
+                shipping = shipping,
                 isBillingInformationRequired = isBillingInformationRequired,
                 isEmailRequired = isEmailRequired,
                 returnUrl = returnUrl,

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentSessionTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexPaymentSessionTest.kt
@@ -1,6 +1,15 @@
 package com.airwallex.android.core
 
 import com.airwallex.android.core.model.PaymentIntentFixtures
+import com.airwallex.android.core.model.Shipping
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
+import org.junit.Before
 import org.junit.Test
 import java.math.BigDecimal
 import kotlin.test.assertEquals
@@ -9,8 +18,22 @@ import kotlin.test.assertTrue
 
 class AirwallexPaymentSessionTest {
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockkObject(TokenManager)
+        every { TokenManager.updateClientSecret(any()) } just runs
+    }
+
     @Test
     fun buildTest() {
+        val shipping = Shipping.Builder()
+            .setFirstName("John")
+            .setLastName("Doe")
+            .build()
+
         val airwallexPaymentSession = AirwallexPaymentSession.Builder(
             PaymentIntentFixtures.PAYMENT_INTENT, "CN"
         )
@@ -20,6 +43,7 @@ class AirwallexPaymentSessionTest {
             .setPaymentMethods(listOf("googlepay"))
             .setHidePaymentConsents(false)
             .setAutoCapture(false)
+            .setShipping(shipping)
             .build()
 
         assertNotNull(airwallexPaymentSession)
@@ -35,12 +59,11 @@ class AirwallexPaymentSessionTest {
 
         assertTrue(airwallexPaymentSession.isEmailRequired)
 
-        assertEquals(null, airwallexPaymentSession.shipping)
-
         assertEquals("cus_ps8e0ZgQzd2QnCxVpzJrHD6KOVu", airwallexPaymentSession.customerId)
         assertEquals("airwallexcheckout://com.airwallex.paymentacceptance", airwallexPaymentSession.returnUrl)
         assertEquals(false, airwallexPaymentSession.autoCapture)
         assertEquals(false, airwallexPaymentSession.hidePaymentConsents)
         assertNotNull(airwallexPaymentSession.paymentMethods)
+        assertEquals(airwallexPaymentSession.shipping, shipping)
     }
 }

--- a/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringWithIntentSessionTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/AirwallexRecurringWithIntentSessionTest.kt
@@ -2,6 +2,7 @@ package com.airwallex.android.core
 
 import com.airwallex.android.core.model.PaymentConsent
 import com.airwallex.android.core.model.PaymentIntentFixtures
+import com.airwallex.android.core.model.Shipping
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkObject
@@ -36,6 +37,10 @@ class AirwallexRecurringWithIntentSessionTest {
 
     @Test
     fun buildTest() {
+        val shipping = Shipping.Builder()
+            .setFirstName("John")
+            .setLastName("Doe")
+            .build()
         val googlePayOptions = GooglePayOptions(
             billingAddressRequired = true,
             billingAddressParameters = BillingAddressParameters(BillingAddressParameters.Format.FULL),
@@ -54,14 +59,13 @@ class AirwallexRecurringWithIntentSessionTest {
             .setAutoCapture(false)
             .setGooglePayOptions(googlePayOptions)
             .setPaymentMethods(listOf("googlepay"))
+            .setShipping(shipping)
             .build()
 
         assertNotNull(airwallexRecurringWithIntentSession)
 
-        assertNotNull(airwallexRecurringWithIntentSession.currency)
         assertEquals("AUD", airwallexRecurringWithIntentSession.currency)
 
-        assertNotNull(airwallexRecurringWithIntentSession.amount)
         assertEquals(BigDecimal.valueOf(100.01), airwallexRecurringWithIntentSession.amount)
 
         assertNotNull(airwallexRecurringWithIntentSession.nextTriggerBy)
@@ -70,16 +74,11 @@ class AirwallexRecurringWithIntentSessionTest {
             airwallexRecurringWithIntentSession.nextTriggerBy
         )
 
-        assertNotNull(airwallexRecurringWithIntentSession.requiresCVC)
         assertEquals(true, airwallexRecurringWithIntentSession.requiresCVC)
-
         assertNotNull(airwallexRecurringWithIntentSession.isBillingInformationRequired)
         assertEquals(false, airwallexRecurringWithIntentSession.isBillingInformationRequired)
 
         assertTrue(airwallexRecurringWithIntentSession.isEmailRequired)
-
-        assertEquals(null, airwallexRecurringWithIntentSession.shipping)
-
         assertNotNull(airwallexRecurringWithIntentSession.customerId)
         assertEquals(
             "cus_ps8e0ZgQzd2QnCxVpzJrHD6KOVu",
@@ -101,5 +100,6 @@ class AirwallexRecurringWithIntentSessionTest {
         )
         assertEquals(false, airwallexRecurringWithIntentSession.autoCapture)
         assertNotNull(airwallexRecurringWithIntentSession.paymentMethods)
+        assertEquals(airwallexRecurringWithIntentSession.shipping, shipping)
     }
 }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/APIIntegrationViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/APIIntegrationViewModel.kt
@@ -273,6 +273,7 @@ class APIIntegrationViewModel : BaseViewModel() {
             .setAutoCapture(autoCapture)
             .setHidePaymentConsents(false)
             .setPaymentMethods(listOf())
+            .setShipping(shipping)
             .build()
 
     /**
@@ -326,6 +327,7 @@ class APIIntegrationViewModel : BaseViewModel() {
             .setAutoCapture(autoCapture)
             .setPaymentMethods(listOf())
             .setGooglePayOptions(googlePayOptions)
+            .setShipping(shipping)
             .build()
 
 }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/UIIntegrationViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/UIIntegrationViewModel.kt
@@ -191,6 +191,7 @@ class UIIntegrationViewModel : BaseViewModel() {
             .setAutoCapture(autoCapture)
             .setHidePaymentConsents(false)
             .setPaymentMethods(paymentMethods)
+            .setShipping(shipping)
             .build()
 
     /**
@@ -237,6 +238,7 @@ class UIIntegrationViewModel : BaseViewModel() {
             .setAutoCapture(autoCapture)
             .setGooglePayOptions(googlePayOptions)
             .setPaymentMethods(paymentMethods)
+            .setShipping(shipping)
             .build()
 
 }


### PR DESCRIPTION
Make `PaymentSession` and `PaymentWithIntentSession` always use billing from setter rather than from intent response.