### PR TITLE
[APAM-629] 3ds & gpay cancel callback will stay on the Payment page instead of redirecting to UIIntegrationActivity

### DIFF
--- a/.maestro/Card/test_guest_payment_cancel_3ds.yaml
+++ b/.maestro/Card/test_guest_payment_cancel_3ds.yaml
@@ -38,11 +38,9 @@ platform:
 - runFlow:
     file: ../Common/flow_handle_3ds.yaml
     env:
-      CANCEL_3DS: true 
-- runFlow:
-    file: ../Common/flow_handle_payment_result.yaml
-    env:
-      PAYMENT_RESULT: FAILED # SUCCESS/FAILED/CANCELLED
+      CANCEL_3DS: true
+- assertVisible: "Pay"
+- tapOn: "Navigate up"
 - runFlow:
     when:
       true: ${IS_RECORDING}

--- a/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodActivity.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodActivity.kt
@@ -25,6 +25,7 @@ import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexSession
 import com.airwallex.android.core.exception.AirwallexException
+import com.airwallex.android.core.exception.ThreeDSCancelledException
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.TrackablePage
@@ -137,7 +138,24 @@ internal class AddPaymentMethodActivity : AirwallexCheckoutBaseActivity(), Track
                         }
 
                         is AirwallexPaymentStatus.Failure -> {
-                            finishWithPaymentIntent(exception = status.exception)
+                            // Check if it's a 3DS cancellation - stay open to allow retry
+                            if (status.exception is ThreeDSCancelledException) {
+                                setLoadingProgress(false)
+                                alert(
+                                    title = "Payment cancelled",
+                                    message = status.exception.message ?: "User cancel the payment"
+                                )
+                            } else {
+                                finishWithPaymentIntent(exception = status.exception)
+                            }
+                        }
+
+                        is AirwallexPaymentStatus.Cancel -> {
+                            setLoadingProgress(false)
+                            alert(
+                                title = "Payment cancelled",
+                                message = "User cancel the payment"
+                            )
                         }
 
                         else -> Unit

--- a/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodActivity.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/AddPaymentMethodActivity.kt
@@ -141,10 +141,6 @@ internal class AddPaymentMethodActivity : AirwallexCheckoutBaseActivity(), Track
                             // Check if it's a 3DS cancellation - stay open to allow retry
                             if (status.exception is ThreeDSCancelledException) {
                                 setLoadingProgress(false)
-                                alert(
-                                    title = "Payment cancelled",
-                                    message = status.exception.message ?: "User cancel the payment"
-                                )
                             } else {
                                 finishWithPaymentIntent(exception = status.exception)
                             }
@@ -152,10 +148,6 @@ internal class AddPaymentMethodActivity : AirwallexCheckoutBaseActivity(), Track
 
                         is AirwallexPaymentStatus.Cancel -> {
                             setLoadingProgress(false)
-                            alert(
-                                title = "Payment cancelled",
-                                message = "User cancel the payment"
-                            )
                         }
 
                         else -> Unit

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsActivity.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsActivity.kt
@@ -143,10 +143,6 @@ class PaymentMethodsActivity : AirwallexCheckoutBaseActivity(), TrackablePage {
                 // Check if it's a 3DS cancellation - stay open to allow retry
                 if (status.exception is ThreeDSCancelledException) {
                     setLoadingProgress(false)
-                    alert(
-                        title = "Payment cancelled",
-                        message = status.exception.message ?: "Payment cancelled"
-                    )
                 } else {
                     finishWithPaymentIntent(exception = status.exception)
                 }
@@ -161,10 +157,6 @@ class PaymentMethodsActivity : AirwallexCheckoutBaseActivity(), TrackablePage {
 
             is AirwallexPaymentStatus.Cancel -> {
                 setLoadingProgress(false)
-                alert(
-                    title = "Payment cancelled",
-                    message = "User cancel the payment"
-                )
             }
         }
     }

--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsActivity.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentMethodsActivity.kt
@@ -13,6 +13,7 @@ import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexSession
 import com.airwallex.android.core.exception.AirwallexException
+import com.airwallex.android.core.exception.ThreeDSCancelledException
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.log.TrackablePage
 import com.airwallex.android.databinding.ActivityPaymentMethodsBinding
@@ -139,7 +140,16 @@ class PaymentMethodsActivity : AirwallexCheckoutBaseActivity(), TrackablePage {
             }
 
             is AirwallexPaymentStatus.Failure -> {
-                finishWithPaymentIntent(exception = status.exception)
+                // Check if it's a 3DS cancellation - stay open to allow retry
+                if (status.exception is ThreeDSCancelledException) {
+                    setLoadingProgress(false)
+                    alert(
+                        title = "Payment cancelled",
+                        message = status.exception.message ?: "Payment cancelled"
+                    )
+                } else {
+                    finishWithPaymentIntent(exception = status.exception)
+                }
             }
 
             is AirwallexPaymentStatus.InProgress -> {
@@ -151,6 +161,10 @@ class PaymentMethodsActivity : AirwallexCheckoutBaseActivity(), TrackablePage {
 
             is AirwallexPaymentStatus.Cancel -> {
                 setLoadingProgress(false)
+                alert(
+                    title = "Payment cancelled",
+                    message = "User cancel the payment"
+                )
             }
         }
     }

--- a/components-core/src/main/java/com/airwallex/android/core/exception/ThreeDSCancelledException.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/exception/ThreeDSCancelledException.kt
@@ -1,0 +1,8 @@
+package com.airwallex.android.core.exception
+
+/**
+ * Exception thrown when user cancels 3D Secure authentication
+ */
+class ThreeDSCancelledException(
+    message: String = "3DS has been cancelled!"
+) : AirwallexException(null, null, 0, message)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
@@ -296,7 +296,7 @@ class EmbeddedElementActivity :
             is AirwallexPaymentStatus.Failure -> {
                 AirwallexLogger.error("Payment failed", status.exception)
                 if (status.exception is ThreeDSCancelledException) {
-                    showPaymentCancelled(status.exception.message)
+                    showPaymentCancelled()
                 } else {
                     showPaymentError(status.exception.localizedMessage)
                 }

--- a/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
@@ -17,6 +17,7 @@ import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.PaymentMethodsLayoutType
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.AirwallexSupportedCard
+import com.airwallex.android.core.exception.ThreeDSCancelledException
 import com.airwallex.android.ui.composables.AirwallexColor
 import com.airwallex.android.view.composables.PaymentElement
 import com.airwallex.android.view.composables.PaymentElementConfiguration
@@ -294,7 +295,11 @@ class EmbeddedElementActivity :
 
             is AirwallexPaymentStatus.Failure -> {
                 AirwallexLogger.error("Payment failed", status.exception)
-                showPaymentError(status.exception.localizedMessage)
+                if (status.exception is ThreeDSCancelledException) {
+                    showPaymentCancelled(status.exception.message)
+                } else {
+                    showPaymentError(status.exception.localizedMessage)
+                }
             }
 
             is AirwallexPaymentStatus.Cancel -> {

--- a/sample/src/main/java/com/airwallex/paymentacceptance/util/PaymentStatusPoller.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/util/PaymentStatusPoller.kt
@@ -20,7 +20,7 @@ import kotlin.math.pow
  *
  * Features:
  * - Exponential backoff: 2s → 4s → 8s → 16s (max)
- * - Maximum polling duration: 5 minutes
+ * - Maximum polling duration: 30 seconds
  * - Final status detection
  * - Lifecycle-aware: waits when app goes to background
  */
@@ -28,7 +28,7 @@ class PaymentStatusPoller(
     private val intentId: String,
     private val clientSecret: String,
     private val airwallex: Airwallex,
-    private val maxPollingDuration: Long = 300_000L, // 5 minutes
+    private val maxPollingDuration: Long = 30_000L, // 30 seconds
     private val baseInterval: Long = 2000L,
     private val maxInterval: Long = 16_000L
 ) {

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="select_payment_failed">Select PaymentMethod failed</string>
     <string name="payment_failed_message">There was an error while processing your payment. Please try again.</string>
     <string name="payment_cancelled">Payment cancelled</string>
-    <string name="payment_cancelled_message">User cancel the payment</string>
+    <string name="payment_cancelled_message">Your payment has been cancelled</string>
 
     <string name="price_value">1</string>
     <string name="currency_value">HKD</string>

--- a/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityActivity.kt
+++ b/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityActivity.kt
@@ -8,8 +8,8 @@ import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexApiRepository
 import com.airwallex.android.core.AirwallexPaymentManager
 import com.airwallex.android.core.PaymentManager
-import com.airwallex.android.core.exception.AirwallexCheckoutException
 import com.airwallex.android.core.exception.AirwallexException
+import com.airwallex.android.core.exception.ThreeDSCancelledException
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.model.PaymentIntent
@@ -35,7 +35,7 @@ class ThreeDSecurityActivity : AirwallexActivity() {
     }
 
     override fun onBackButtonPressed() {
-        finishWithData(exception = AirwallexCheckoutException(message = "3DS has been cancelled!"))
+        finishWithData(exception = ThreeDSCancelledException())
     }
 
     override fun homeAsUpIndicatorResId(): Int {


### PR DESCRIPTION
flow changes:
- Embedded will show different text on cancel, to make it same as ios
- HPP will not throw user back to UIIntegrationActivity on 3ds cancel, rather it will just go back to payment page. no alert will be shown

https://github.com/user-attachments/assets/65d419ad-cf34-407c-8018-55a913c1c7c7

