### PR TITLE
fix: filter google pay properly if it's shown as primary button

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentMethodsAccordionSection.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentMethodsAccordionSection.kt
@@ -73,12 +73,9 @@ internal fun PaymentMethodsAccordionSection(
     )
     val availablePaymentMethods by flowViewModel.availablePaymentMethods.collectAsState()
     val availablePaymentConsents by flowViewModel.availablePaymentConsents.collectAsState()
-    var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
-    val (selectedOption, onOptionSelected) = remember(selectedIndex, availablePaymentMethods) {
-        mutableStateOf(availablePaymentMethods.getOrNull(selectedIndex) ?: availablePaymentMethods.first())
-    }
 
     if (availablePaymentMethods.getSinglePaymentMethodOrNull(availablePaymentConsents) == null) {
+        var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
         val allowedPaymentMethods = remember(availablePaymentMethods) {
             session.googlePayOptions?.let { googlePayOptions ->
                 availablePaymentMethods.firstOrNull {
@@ -100,15 +97,16 @@ internal fun PaymentMethodsAccordionSection(
                 airwallex = airwallex,
             )
         }
-        val paymentMethodsList = if (showsGooglePayAsPrimaryButton) {
+        // Filter out Google Pay from accordion if it's shown as primary button and is available
+        val paymentMethodsList = if (showsGooglePayAsPrimaryButton && allowedPaymentMethods != null) {
             availablePaymentMethods.filterNot { paymentMethodType ->
                 paymentMethodType.name == PaymentMethodType.GOOGLEPAY.value
             }
         } else {
-            // If Google Pay is not prioritized, filter it out only if allowedPaymentMethods is null
-            availablePaymentMethods.filterNot { paymentMethodType ->
-                paymentMethodType.name == PaymentMethodType.GOOGLEPAY.value && allowedPaymentMethods == null
-            }
+            availablePaymentMethods
+        }
+        val (selectedOption, onOptionSelected) = remember(selectedIndex, paymentMethodsList) {
+            mutableStateOf(paymentMethodsList.getOrNull(selectedIndex) ?: paymentMethodsList.first())
         }
         Column(
             modifier = Modifier.fillMaxWidth(),

--- a/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentMethodsTabSection.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentMethodsTabSection.kt
@@ -74,9 +74,6 @@ internal fun PaymentMethodsTabSection(
         val coroutineScope = rememberCoroutineScope()
 
         var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
-        var type by remember(selectedIndex, availablePaymentMethods) {
-            mutableStateOf(availablePaymentMethods.getOrNull(selectedIndex) ?: availablePaymentMethods.first())
-        }
         val allowedPaymentMethods = remember(availablePaymentMethods) {
             session.googlePayOptions?.let { googlePayOptions ->
                 availablePaymentMethods.firstOrNull {
@@ -99,12 +96,16 @@ internal fun PaymentMethodsTabSection(
                     airwallex = airwallex,
                 )
             }
-            val paymentMethodsList = if (showsGooglePayAsPrimaryButton || allowedPaymentMethods == null) {
+            // Filter out Google Pay from tabs if it's shown as primary button and is available
+            val paymentMethodsList = if (showsGooglePayAsPrimaryButton && allowedPaymentMethods != null) {
                 availablePaymentMethods.filterNot { paymentMethodType ->
                     paymentMethodType.name == PaymentMethodType.GOOGLEPAY.value
                 }
             } else {
                 availablePaymentMethods
+            }
+            var type by remember(selectedIndex, availablePaymentMethods) {
+                mutableStateOf(paymentMethodsList.getOrNull(selectedIndex) ?: availablePaymentMethods.first())
             }
             if (paymentMethodsList.getSinglePaymentMethodOrNull(availablePaymentConsents) == null) {
                 LazyRow(


### PR DESCRIPTION
root cause: if payment methods list are: card, alipaycn, alipayhk, googlepay, paypal
the tabs will show card - alipay - alipayhk - paypal, but if paypal is clicked, it will show googlepay
this is because the googlepay is filtered whens howing the tab list but when getting the active payment method, it is filtered from the unfiltered availablePaymentMethods with googlepay
fix: get from the filtered methods if showsAsPrimaryButton is true, but just do it as usual if false (because the title googlepay exists within the list)

https://github.com/user-attachments/assets/45db0917-8a4b-4acc-89db-3d3a45f1dfcb


https://github.com/user-attachments/assets/61068d47-f488-4c44-b7a8-08c4725fadc4

