### PR TITLE
fix: embedded element polling to start after redirect

### DIFF
--- a/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/ui/EmbeddedElementActivity.kt
@@ -70,6 +70,12 @@ class EmbeddedElementActivity :
         setupObservers()
     }
 
+    override fun onResume() {
+        super.onResume()
+        // Start polling when activity resumes (e.g., returning from redirect)
+        mViewModel.startPendingPollingIfNeeded()
+    }
+
     private fun setupColors() {
         mBinding.root.setBackgroundColor(AirwallexColor.backgroundPrimary.toArgb())
         mBinding.toolbar.setBackgroundColor(AirwallexColor.backgroundPrimary.toArgb())

--- a/sample/src/main/java/com/airwallex/paymentacceptance/util/PaymentStatusPoller.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/util/PaymentStatusPoller.kt
@@ -49,6 +49,9 @@ class PaymentStatusPoller(
     /**
      * Poll for payment status until final state or timeout.
      * This is a suspend function that returns the final result.
+     *
+     * Note: This should only be called when the app is already in foreground
+     * (e.g., after user returns from redirect). The timer starts immediately.
      */
     suspend fun getPaymentAttempt(): PollingResult {
         pollingJob = currentCoroutineContext().job

--- a/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/EmbeddedElementViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/EmbeddedElementViewModel.kt
@@ -19,9 +19,10 @@ class EmbeddedElementViewModel : BaseViewModel() {
 
     /**
      * Handle payment result from PaymentElement
+     * Defers polling until activity resumes (user returns from redirect)
      */
     fun handlePaymentResult(status: AirwallexPaymentStatus) {
-        session?.let { handlePaymentStatus(it, status) }
+        session?.let { handlePaymentStatus(it, status, deferPolling = true) }
     }
 
     /**

--- a/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/base/BaseViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/base/BaseViewModel.kt
@@ -56,6 +56,10 @@ abstract class BaseViewModel : ViewModel() {
     private val _pollingResult = MutableSharedFlow<PaymentStatusPoller.PollingResult>()
     val pollingResult: SharedFlow<PaymentStatusPoller.PollingResult> = _pollingResult.asSharedFlow()
 
+    // Pending polling state - set when InProgress is received, cleared when polling starts
+    private var pendingPollingIntentId: String? = null
+    private var pendingPollingClientSecret: String? = null
+
     // Activity reference for creating Airwallex instance
     protected var activity: ComponentActivity? = null
 
@@ -82,6 +86,7 @@ abstract class BaseViewModel : ViewModel() {
     override fun onCleared() {
         super.onCleared()
         paymentStatusPoller?.stop()
+        clearPendingPolling()
         stopLoading()
     }
 
@@ -91,32 +96,67 @@ abstract class BaseViewModel : ViewModel() {
     fun stopPolling() {
         paymentStatusPoller?.stop()
         paymentStatusPoller = null
+        clearPendingPolling()
         stopLoading()
     }
 
     /**
-     * Handle payment status - start polling for InProgress, emit status for others
+     * Handle payment status - start/defer polling for InProgress based on deferPolling flag
+     * @param session The Airwallex session
+     * @param status The payment status
+     * @param deferPolling If true, defer polling until startPendingPollingIfNeeded() is called (for embedded element).
+     *                     If false, start polling immediately (for HPP/UI integration).
      */
     protected fun handlePaymentStatus(
         session: AirwallexSession,
-        status: AirwallexPaymentStatus
+        status: AirwallexPaymentStatus,
+        deferPolling: Boolean = false
     ) {
         viewModelScope.launch {
             if (status is AirwallexPaymentStatus.InProgress) {
-                // Start polling for InProgress status
                 status.paymentIntentId?.let { intentId ->
                     val clientSecret = getClientSecretFromSession(session)
                     if (clientSecret.isNotEmpty()) {
-                        startPolling(intentId, clientSecret)
+                        if (deferPolling) {
+                            // Defer polling - wait for user to return from redirect
+                            pendingPollingIntentId = intentId
+                            pendingPollingClientSecret = clientSecret
+                            Log.d(TAG, "Polling deferred for intentId: $intentId, will start when activity resumes")
+                        } else {
+                            // Start polling immediately
+                            Log.d(TAG, "Starting polling immediately for intentId: $intentId")
+                            startPolling(intentId, clientSecret)
+                        }
                     } else {
                         Log.e(TAG, "Client secret is null, cannot start polling")
                     }
                 }
             } else {
                 stopLoading()
+                clearPendingPolling()
             }
             _airwallexPaymentStatus.emit(status)
         }
+    }
+
+    /**
+     * Start polling if there's a pending poll request
+     * Should be called from Activity.onResume() when returning from redirect
+     */
+    fun startPendingPollingIfNeeded() {
+        val intentId = pendingPollingIntentId
+        val clientSecret = pendingPollingClientSecret
+
+        if (intentId != null && clientSecret != null) {
+            Log.d(TAG, "Activity resumed, starting pending polling for intentId: $intentId")
+            startPolling(intentId, clientSecret)
+            clearPendingPolling()
+        }
+    }
+
+    private fun clearPendingPolling() {
+        pendingPollingIntentId = null
+        pendingPollingClientSecret = null
     }
 
     /**


### PR DESCRIPTION
issue: polling max time is reduced from 5 mins to 30 secs. the problem is embedded element starts the poller countdown the moment it receives INPROGRESS status (before redirect). if the redirection takes > 30 seconds, it will show error.
solution: for embedded element, upon starting, just set the pending intent id, and onresume will actually start. for HPP, UIIntegrationActivity will start the polling immediately