### PR TITLE
[APAM-678] Chain repo-dispatch after maven publish on release trigger

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,6 @@ jobs:
 
   repo-dispatch:
     needs: maven
-    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
     uses: ./.github/workflows/repo-dispatch-on-release.yml
     with:
       tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,8 @@ name: Push release to Maven
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   maven:
@@ -37,3 +36,11 @@ jobs:
           SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_BASE64 }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           AIRWALLEX_VERSION_CODE: ${{ github.run_number }}
+
+  repo-dispatch:
+    needs: maven
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    uses: ./.github/workflows/repo-dispatch-on-release.yml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets: inherit

--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -1,8 +1,12 @@
 name: Repo Dispatch on Android Release
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Android SDK version (e.g., 6.3.0)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -14,19 +18,8 @@ jobs:
   repo-dispatch-on-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Set version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-            ACTION="manual"
-          else
-            VERSION="${{ github.event.release.tag_name }}"
-            ACTION="${{ github.event.action }}"
-          fi
-          echo "tag=$VERSION" >> $GITHUB_OUTPUT
-          echo "action=$ACTION" >> $GITHUB_OUTPUT
-          echo "Dispatching for version: $VERSION (action: $ACTION)"
+      - name: Log version
+        run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
       - name: Send repository dispatch to Flutter SDK
         env:
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}
@@ -34,8 +27,7 @@ jobs:
           gh api repos/airwallex/airwallex-payment-flutter/dispatches \
             --method POST \
             --field event_type='android_release' \
-            --field client_payload[tag]='${{ steps.version.outputs.tag }}' \
-            --field client_payload[action]='${{ steps.version.outputs.action }}'
+            --field client_payload[tag]='${{ inputs.tag }}'
 
       - name: Send repository dispatch to React Native SDK
         env:
@@ -44,5 +36,4 @@ jobs:
           gh api repos/airwallex/airwallex-payment-react-native/dispatches \
             --method POST \
             --field event_type='android_release' \
-            --field client_payload[tag]='${{ steps.version.outputs.tag }}' \
-            --field client_payload[action]='${{ steps.version.outputs.action }}'
+            --field client_payload[tag]='${{ inputs.tag }}'


### PR DESCRIPTION
## Summary
- Switch `maven.yml` trigger from `push.tags` to `release: [published]`
- Chain `repo-dispatch-on-release.yml` as a reusable workflow (`workflow_call`) after successful maven publish, gated on non-prerelease
- Simplify repo-dispatch workflow by removing version-resolution logic and `action` payload field

Mirrors the iOS approach: airwallex/airwallex-payment-ios#268

## Test plan
- [ ] Create a release and verify maven publish runs followed by repo-dispatch
- [ ] Verify prerelease does not trigger repo-dispatch
- [ ] Verify `workflow_dispatch` still works for manual runs on both workflows
- [ ] Confirm Flutter and React Native repos receive `android_release` dispatch with correct `tag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)