### PR TITLE
fix: resolve implementation during publish maven module

### DIFF
--- a/publish-module.gradle
+++ b/publish-module.gradle
@@ -122,9 +122,41 @@ project.afterEvaluate {
                     configurations.implementation.dependencies.each {
                         if (it.name != 'unspecified') {
                             def dependencyNode = dependenciesNode.appendNode('dependency')
-                            dependencyNode.appendNode('groupId', it.group)
-                            dependencyNode.appendNode('artifactId', it.name)
-                            dependencyNode.appendNode('version', it.version)
+                            dependencyNode.appendNode('groupId', it.group != rootProject.name ? it.group : airwallexGroupId)
+
+                            if (it.group == rootProject.name) {
+                                switch (it.name) {
+                                    case 'airwallex':
+                                        dependencyNode.appendNode('artifactId', 'payment')
+                                        break
+                                    case 'card':
+                                        dependencyNode.appendNode('artifactId', 'payment-card')
+                                        break
+                                    case 'wechat':
+                                        dependencyNode.appendNode('artifactId', 'payment-wechat')
+                                        break
+                                    case 'redirect':
+                                        dependencyNode.appendNode('artifactId', 'payment-redirect')
+                                        break
+                                    case 'googlepay':
+                                        dependencyNode.appendNode('artifactId', 'payment-googlepay')
+                                        break
+                                    case 'ui-core':
+                                        dependencyNode.appendNode('artifactId', "payment-ui-core")
+                                        break
+                                    case 'components-core':
+                                        dependencyNode.appendNode('artifactId', 'payment-components-core')
+                                        break
+                                    case 'security-3ds':
+                                        dependencyNode.appendNode('artifactId', 'payment-3ds')
+                                        break
+                                    default:
+                                        break
+                                }
+                            } else {
+                                dependencyNode.appendNode('artifactId', it.name)
+                            }
+                            dependencyNode.appendNode('version', it.version != 'unspecified' ? it.version : rootProject.version)
                             dependencyNode.appendNode('scope', 'compile')
                         }
                     }


### PR DESCRIPTION
have the logic for `implementation` same as `api` during publish module so maven build. will able to resolve dependencies. this was because the googlepay buildgradle now uses implementation instead of api for ui-core