### PR TITLE
fix: ensure deprecated function is still working, and also fix express checkout HPP only support visa

### DIFF
--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -291,10 +291,10 @@ class Airwallex internal constructor(
         paymentConsentId: String,
         listener: PaymentResultListener
     ) {
-        if (session !is Session && session !is AirwallexPaymentSession) {
+        if (session !is AirwallexPaymentSession) {
             listener.onCompleted(
                 AirwallexPaymentStatus.Failure(
-                    AirwallexCheckoutException(message = "checkout with paymentConsent only support AirwallexPaymentSession or Session")
+                    AirwallexCheckoutException(message = "checkout with paymentConsent only support AirwallexPaymentSession")
                 )
             )
             return
@@ -305,7 +305,7 @@ class Airwallex internal constructor(
         checkout(
             session = session,
             paymentMethod = PaymentMethod(type = PaymentMethodType.CARD.value),
-            paymentConsentId = paymentConsentId,
+            paymentConsent = PaymentConsent(id = paymentConsentId, nextTriggeredBy = PaymentConsent.NextTriggeredBy.CUSTOMER),
             listener = listener
         )
     }

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -295,10 +295,10 @@ class Airwallex internal constructor(
         paymentConsentId: String,
         listener: PaymentResultListener
     ) {
-        if (session !is AirwallexPaymentSession) {
+        if (session !is Session && session !is AirwallexPaymentSession) {
             listener.onCompleted(
                 AirwallexPaymentStatus.Failure(
-                    AirwallexCheckoutException(message = "checkout with paymentConsent only support AirwallexPaymentSession")
+                    AirwallexCheckoutException(message = "checkout with paymentConsent only support AirwallexPaymentSession or Session")
                 )
             )
             return
@@ -309,7 +309,7 @@ class Airwallex internal constructor(
         checkout(
             session = session,
             paymentMethod = PaymentMethod(type = PaymentMethodType.CARD.value),
-            paymentConsent = PaymentConsent(id = paymentConsentId, nextTriggeredBy = PaymentConsent.NextTriggeredBy.CUSTOMER),
+            paymentConsentId = paymentConsentId,
             listener = listener
         )
     }
@@ -950,10 +950,26 @@ class Airwallex internal constructor(
         // 2. OR paymentMethod.type is NOT card/googlepay (LPMs use legacy flow)
         // Otherwise: use new unified flow with Session
         val loggingListener = wrapListenerWithLogging(listener, paymentMethod.type ?: "unknown")
+        val effectivePaymentConsent = if (paymentConsentId != null && paymentConsent == null) {
+            val isOneOff = session is AirwallexPaymentSession || (session is Session && session.isOneOffPayment)
+            if (!isOneOff) {
+                loggingListener.onCompleted(
+                    AirwallexPaymentStatus.Failure(
+                        AirwallexCheckoutException(message = "checkout with paymentConsentId only support oneoff payment")
+                    )
+                )
+                return
+            }
+            PaymentConsent(
+                id = paymentConsentId,
+                nextTriggeredBy = PaymentConsent.NextTriggeredBy.CUSTOMER,
+            )
+        } else {
+            paymentConsent
+        }
         val isCardOrGooglePay = paymentMethod.type == PaymentMethodType.GOOGLEPAY.value ||
                                 paymentMethod.type == PaymentMethodType.CARD.value
         val useOldFlow = session is AirwallexRecurringSession || !isCardOrGooglePay
-        val latestConsentObject = createPaymentConsentFromId(paymentConsent, paymentConsentId, session)
         val paymentConsentIdValue = paymentConsentId ?: paymentConsent?.id
 
         // Log payment_launched for API integration
@@ -992,7 +1008,7 @@ class Airwallex internal constructor(
             }
 
         // Call unified Session checkout
-        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, latestConsentObject, loggingListener)
+        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, effectivePaymentConsent, loggingListener)
     }
 
     private fun handleCheckoutApiWithCvc(
@@ -1026,27 +1042,6 @@ class Airwallex internal constructor(
                 )
             )
         }
-    }
-
-    private fun createPaymentConsentFromId(
-        paymentConsent: PaymentConsent?,
-        paymentConsentId: String?,
-        session: AirwallexSession
-    ): PaymentConsent? {
-        return paymentConsent
-            ?: if (paymentConsentId != null) {
-                val nextTriggeredBy = when (session) {
-                    is Session ->
-                        session.paymentConsentOptions?.nextTriggeredBy
-                        ?: PaymentConsent.NextTriggeredBy.CUSTOMER
-
-                    is AirwallexPaymentSession -> PaymentConsent.NextTriggeredBy.CUSTOMER
-                    is AirwallexRecurringSession -> session.nextTriggerBy
-                    is AirwallexRecurringWithIntentSession -> session.nextTriggerBy
-                    else -> PaymentConsent.NextTriggeredBy.CUSTOMER
-                }
-                PaymentConsent(id = paymentConsentId, nextTriggeredBy = nextTriggeredBy)
-            } else null
     }
 
     /**

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -976,12 +976,7 @@ class Airwallex internal constructor(
         logPaymentLaunchedIfNeeded(paymentConsentIdValue, paymentMethod.type)
 
         // Saved-card via API: capture CVC through the card provider before continuing if PAN.
-        val isFromApi = !isAirwallexUIActivity &&
-                AnalyticsLogger.getLaunchType() == AnalyticsLogger.LaunchType.API
-        if (!paymentConsentIdValue.isNullOrEmpty() &&
-            paymentMethod.card?.numberType == PaymentMethod.Card.NumberType.PAN &&
-            isFromApi
-        ) {
+        if (isCheckoutApiWithCvc(paymentMethod, paymentConsentIdValue)) {
             handleCheckoutApiWithCvc(paymentMethod, session, paymentConsentIdValue, loggingListener)
             return
         }
@@ -992,29 +987,42 @@ class Airwallex internal constructor(
         }
 
         // NEW FLOW: Use unified Session flow for card/googlepay
-        // Convert legacy to Session if needed
-        val unifiedSession = session as? Session
+        val unifiedSession = toUnifiedSession(session)
+        if (unifiedSession == null) {
+            loggingListener.onCompleted(
+                AirwallexPaymentStatus.Failure(
+                    AirwallexCheckoutException(message = "Unknown session type: ${session.javaClass}")
+                )
+            )
+            return
+        }
+        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, effectivePaymentConsent, loggingListener)
+    }
+
+    private fun toUnifiedSession(session: AirwallexSession): Session? {
+        return session as? Session
             ?: when (session) {
                 is AirwallexPaymentSession -> session.convertToSession()
                 is AirwallexRecurringWithIntentSession -> session.convertToSession()
-                else -> {
-                    loggingListener.onCompleted(
-                        AirwallexPaymentStatus.Failure(
-                            AirwallexCheckoutException(message = "Unknown session type: ${session.javaClass}")
-                        )
-                    )
-                    return
-                }
+                else -> null
             }
+    }
 
-        // Call unified Session checkout
-        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, effectivePaymentConsent, loggingListener)
+    private fun isCheckoutApiWithCvc(
+        paymentMethod: PaymentMethod,
+        paymentConsentIdValue: String?,
+    ): Boolean {
+        val isFromApi = !isAirwallexUIActivity &&
+                AnalyticsLogger.getLaunchType() == AnalyticsLogger.LaunchType.API
+        return !paymentConsentIdValue.isNullOrEmpty() &&
+                paymentMethod.card?.numberType == PaymentMethod.Card.NumberType.PAN &&
+                isFromApi
     }
 
     private fun handleCheckoutApiWithCvc(
         paymentMethod: PaymentMethod,
         session: AirwallexSession,
-        paymentConsentIdValue: String,
+        paymentConsentIdValue: String?,
         loggingListener: PaymentResultListener
     ) {
         AirwallexLogger.info("checkout, need cvc")

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -953,53 +953,20 @@ class Airwallex internal constructor(
         val isCardOrGooglePay = paymentMethod.type == PaymentMethodType.GOOGLEPAY.value ||
                                 paymentMethod.type == PaymentMethodType.CARD.value
         val useOldFlow = session is AirwallexRecurringSession || !isCardOrGooglePay
-        val latestConsentObject = paymentConsent
-            ?: if (paymentConsentId != null) {
-                val nextTriggeredBy = when(session) {
-                    is Session -> session.paymentConsentOptions?.nextTriggeredBy ?: PaymentConsent.NextTriggeredBy.CUSTOMER
-                    is AirwallexPaymentSession -> PaymentConsent.NextTriggeredBy.CUSTOMER
-                    is AirwallexRecurringSession -> session.nextTriggerBy
-                    is AirwallexRecurringWithIntentSession -> session.nextTriggerBy
-                    else -> PaymentConsent.NextTriggeredBy.CUSTOMER
-                }
-                PaymentConsent(id = paymentConsentId, nextTriggeredBy = nextTriggeredBy)
-            } else null
+        val latestConsentObject = createPaymentConsentFromId(paymentConsent, paymentConsentId, session)
         val paymentConsentIdValue = paymentConsentId ?: paymentConsent?.id
 
         // Log payment_launched for API integration
         logPaymentLaunchedIfNeeded(paymentConsentIdValue, paymentMethod.type)
 
         // Saved-card via API: capture CVC through the card provider before continuing if PAN.
+        val isFromApi = !isAirwallexUIActivity &&
+                AnalyticsLogger.getLaunchType() == AnalyticsLogger.LaunchType.API
         if (!paymentConsentIdValue.isNullOrEmpty() &&
             paymentMethod.card?.numberType == PaymentMethod.Card.NumberType.PAN &&
-            !isAirwallexUIActivity &&
-            AnalyticsLogger.getLaunchType() == AnalyticsLogger.LaunchType.API
+            isFromApi
         ) {
-            AirwallexLogger.info("checkout, need cvc")
-            val provider = AirwallexPlugins.getProvider(ActionComponentProviderType.CARD)
-            provider?.get()?.let { paymentProvider ->
-                paymentProvider.handlePaymentData(
-                    AirwallexCheckoutParam(
-                        activity,
-                        paymentMethod,
-                        session,
-                        paymentConsentIdValue
-                    )
-                ) { status: AirwallexPaymentStatus? ->
-                    loggingListener.onCompleted(
-                        status ?: AirwallexPaymentStatus.Failure(
-                            AirwallexCheckoutException(message = "cvc unknown error")
-                        )
-                    )
-                }
-            } ?: run {
-                AirwallexLogger.error("checkout, Provider is null, unable to handle payment data")
-                loggingListener.onCompleted(
-                    AirwallexPaymentStatus.Failure(
-                        AirwallexComponentDependencyException(dependency = Dependency.CARD)
-                    )
-                )
-            }
+            handleCheckoutApiWithCvc(paymentMethod, session, paymentConsentIdValue, loggingListener)
             return
         }
 
@@ -1026,6 +993,60 @@ class Airwallex internal constructor(
 
         // Call unified Session checkout
         checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, latestConsentObject, loggingListener)
+    }
+
+    private fun handleCheckoutApiWithCvc(
+        paymentMethod: PaymentMethod,
+        session: AirwallexSession,
+        paymentConsentIdValue: String,
+        loggingListener: PaymentResultListener
+    ) {
+        AirwallexLogger.info("checkout, need cvc")
+        val provider = AirwallexPlugins.getProvider(ActionComponentProviderType.CARD)
+        provider?.get()?.let { paymentProvider ->
+            paymentProvider.handlePaymentData(
+                AirwallexCheckoutParam(
+                    activity,
+                    paymentMethod,
+                    session,
+                    paymentConsentIdValue
+                )
+            ) { status: AirwallexPaymentStatus? ->
+                loggingListener.onCompleted(
+                    status ?: AirwallexPaymentStatus.Failure(
+                        AirwallexCheckoutException(message = "cvc unknown error")
+                    )
+                )
+            }
+        } ?: run {
+            AirwallexLogger.error("checkout, Provider is null, unable to handle payment data")
+            loggingListener.onCompleted(
+                AirwallexPaymentStatus.Failure(
+                    AirwallexComponentDependencyException(dependency = Dependency.CARD)
+                )
+            )
+        }
+    }
+
+    private fun createPaymentConsentFromId(
+        paymentConsent: PaymentConsent?,
+        paymentConsentId: String?,
+        session: AirwallexSession
+    ): PaymentConsent? {
+        return paymentConsent
+            ?: if (paymentConsentId != null) {
+                val nextTriggeredBy = when (session) {
+                    is Session ->
+                        session.paymentConsentOptions?.nextTriggeredBy
+                        ?: PaymentConsent.NextTriggeredBy.CUSTOMER
+
+                    is AirwallexPaymentSession -> PaymentConsent.NextTriggeredBy.CUSTOMER
+                    is AirwallexRecurringSession -> session.nextTriggerBy
+                    is AirwallexRecurringWithIntentSession -> session.nextTriggerBy
+                    else -> PaymentConsent.NextTriggeredBy.CUSTOMER
+                }
+                PaymentConsent(id = paymentConsentId, nextTriggeredBy = nextTriggeredBy)
+            } else null
     }
 
     /**

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.airwallex.android.core.Airwallex.Companion.initialize
+import com.airwallex.android.core.data.AirwallexCheckoutParam
 import com.airwallex.android.core.exception.AirwallexCheckoutException
 import com.airwallex.android.core.exception.AirwallexComponentDependencyException
 import com.airwallex.android.core.exception.AirwallexException
@@ -259,8 +260,11 @@ class Airwallex internal constructor(
             loggingListener.onCompleted(AirwallexPaymentStatus.Failure(AirwallexCheckoutException(message = "paymentMethod is required")))
             return
         }
-
-        // Redirect to checkout()
+        if (paymentConsent.id.isNullOrEmpty()) {
+            AirwallexLogger.info("confirmPaymentIntent, paymentConsentId isNullOrEmpty")
+            loggingListener.onCompleted(AirwallexPaymentStatus.Failure(AirwallexCheckoutException(message = "paymentConsentId is required")))
+            return
+        }
         checkout(
             session = session,
             paymentMethod = paymentMethod,
@@ -949,10 +953,55 @@ class Airwallex internal constructor(
         val isCardOrGooglePay = paymentMethod.type == PaymentMethodType.GOOGLEPAY.value ||
                                 paymentMethod.type == PaymentMethodType.CARD.value
         val useOldFlow = session is AirwallexRecurringSession || !isCardOrGooglePay
+        val latestConsentObject = paymentConsent
+            ?: if (paymentConsentId != null) {
+                val nextTriggeredBy = when(session) {
+                    is Session -> session.paymentConsentOptions?.nextTriggeredBy ?: PaymentConsent.NextTriggeredBy.CUSTOMER
+                    is AirwallexPaymentSession -> PaymentConsent.NextTriggeredBy.CUSTOMER
+                    is AirwallexRecurringSession -> session.nextTriggerBy
+                    is AirwallexRecurringWithIntentSession -> session.nextTriggerBy
+                    else -> PaymentConsent.NextTriggeredBy.CUSTOMER
+                }
+                PaymentConsent(id = paymentConsentId, nextTriggeredBy = nextTriggeredBy)
+            } else null
         val paymentConsentIdValue = paymentConsentId ?: paymentConsent?.id
 
         // Log payment_launched for API integration
         logPaymentLaunchedIfNeeded(paymentConsentIdValue, paymentMethod.type)
+
+        // Saved-card via API: capture CVC through the card provider before continuing if PAN.
+        if (!paymentConsentIdValue.isNullOrEmpty() &&
+            paymentMethod.card?.numberType == PaymentMethod.Card.NumberType.PAN &&
+            !isAirwallexUIActivity &&
+            AnalyticsLogger.getLaunchType() == AnalyticsLogger.LaunchType.API
+        ) {
+            AirwallexLogger.info("checkout, need cvc")
+            val provider = AirwallexPlugins.getProvider(ActionComponentProviderType.CARD)
+            provider?.get()?.let { paymentProvider ->
+                paymentProvider.handlePaymentData(
+                    AirwallexCheckoutParam(
+                        activity,
+                        paymentMethod,
+                        session,
+                        paymentConsentIdValue
+                    )
+                ) { status: AirwallexPaymentStatus? ->
+                    loggingListener.onCompleted(
+                        status ?: AirwallexPaymentStatus.Failure(
+                            AirwallexCheckoutException(message = "cvc unknown error")
+                        )
+                    )
+                }
+            } ?: run {
+                AirwallexLogger.error("checkout, Provider is null, unable to handle payment data")
+                loggingListener.onCompleted(
+                    AirwallexPaymentStatus.Failure(
+                        AirwallexComponentDependencyException(dependency = Dependency.CARD)
+                    )
+                )
+            }
+            return
+        }
 
         if (useOldFlow) {
             checkoutOldFlowRouting(session, paymentMethod, cvc, additionalInfo, flow, loggingListener)
@@ -976,7 +1025,7 @@ class Airwallex internal constructor(
             }
 
         // Call unified Session checkout
-        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, paymentConsent, loggingListener)
+        checkoutUnified(unifiedSession, paymentMethod, cvc, saveCard, latestConsentObject, loggingListener)
     }
 
     /**

--- a/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/UIIntegrationViewModel.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/viewmodel/UIIntegrationViewModel.kt
@@ -94,7 +94,6 @@ class UIIntegrationViewModel : BaseViewModel() {
         AirwallexStarter.presentCardPaymentFlow(
             activity = activity,
             session = session,
-            supportedCards = listOf(AirwallexSupportedCard.VISA),
             paymentResultListener = object : Airwallex.PaymentResultListener {
                 override fun onCompleted(status: AirwallexPaymentStatus) {
                     handlePaymentStatus(session, status)

--- a/ui-core/src/main/java/com/airwallex/android/ui/checkout/AirwallexCheckoutViewModel.kt
+++ b/ui-core/src/main/java/com/airwallex/android/ui/checkout/AirwallexCheckoutViewModel.kt
@@ -66,28 +66,6 @@ open class AirwallexCheckoutViewModel(
 
     suspend fun checkout(
         paymentMethod: PaymentMethod,
-        paymentConsentId: String?,
-        cvc: String,
-        flow: AirwallexPaymentRequestFlow = AirwallexPaymentRequestFlow.IN_APP,
-    ): AirwallexPaymentStatus {
-        return suspendCancellableCoroutine { continuation ->
-            airwallex.checkout(
-                session = session,
-                paymentMethod = paymentMethod,
-                paymentConsentId = paymentConsentId,
-                cvc = cvc,
-                flow = flow,
-                listener = object : Airwallex.PaymentResultListener {
-                    override fun onCompleted(status: AirwallexPaymentStatus) {
-                        continuation.resume(status)
-                    }
-                }
-            )
-        }
-    }
-
-    suspend fun checkout(
-        paymentMethod: PaymentMethod,
         additionalInfo: Map<String, String>? = null,
         flow: AirwallexPaymentRequestFlow? = null
     ): AirwallexPaymentStatus {

--- a/ui-core/src/test/java/com/airwallex/android/ui/AirwallexCheckoutViewModelTest.kt
+++ b/ui-core/src/test/java/com/airwallex/android/ui/AirwallexCheckoutViewModelTest.kt
@@ -117,45 +117,6 @@ class AirwallexCheckoutViewModelTest {
         }
     }
 
-    @Test
-    fun `test suspend function checkout with cvc`() = runTest {
-        val flow = mockk<AirwallexPaymentRequestFlow>()
-        val expectedStatus = mockk<AirwallexPaymentStatus>()
-
-        val listenerSlot = slot<Airwallex.PaymentResultListener>()
-
-        coEvery {
-            airwallex.checkout(
-                session = session,
-                paymentMethod = paymentMethod,
-                paymentConsentId = "consentId",
-                cvc = "cvc",
-                flow = flow,
-                listener = capture(listenerSlot)
-            )
-        } answers {
-            listenerSlot.captured.onCompleted(expectedStatus)
-        }
-
-        val result = viewModel.checkout(
-            paymentMethod = paymentMethod,
-            paymentConsentId = "consentId",
-            cvc = "cvc",
-            flow = flow
-        )
-
-        assertEquals(expectedStatus, result)
-        coVerify(exactly = 1) {
-            airwallex.checkout(
-                session = session,
-                paymentMethod = paymentMethod,
-                paymentConsentId = "consentId",
-                cvc = "cvc",
-                flow = flow,
-                listener = capture(listenerSlot)
-            )
-        }
-    }
 
     @Test
     fun `test suspend function checkoutGooglePay`() = runTest {

--- a/ui-core/src/test/java/com/airwallex/android/ui/AirwallexCheckoutViewModelTest.kt
+++ b/ui-core/src/test/java/com/airwallex/android/ui/AirwallexCheckoutViewModelTest.kt
@@ -117,7 +117,6 @@ class AirwallexCheckoutViewModelTest {
         }
     }
 
-
     @Test
     fun `test suspend function checkoutGooglePay`() = runTest {
         val listenerSlot = slot<Airwallex.PaymentResultListener>()


### PR DESCRIPTION
the confirmPaymentIntent previous validation only supports AirwallexPaymentSession, so let's keep it at that. also ensure that it's still working. 
also, previously user can send only paymentConsentId, now it shouldn't because consent needs id and nextTriggeredBy, so removing the param from fun checkout (not public yet)