### PR TITLE
[APAM-697] Restart app when switching SDK environment

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -111,6 +111,12 @@
             tools:ignore="LockedOrientationActivity" />
 
         <activity
+            android:name=".ui.RestartActivity"
+            android:exported="false"
+            android:process=":restart"
+            tools:ignore="LockedOrientationActivity" />
+
+        <activity
             android:name=".ui.EmbeddedElementActivity"
             android:exported="true"
             android:launchMode="singleTask"

--- a/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/Settings.kt
@@ -347,6 +347,10 @@ object Settings {
             )?.takeIf { it.isNotBlank() } ?: defaultCountryCode
         }
 
+    fun flush() {
+        sharedPreferences.edit(commit = true) {}
+    }
+
     private fun getMetadata(key: String): String? {
         return context.packageManager
             .getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)

--- a/sample/src/main/java/com/airwallex/paymentacceptance/ui/RestartActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/ui/RestartActivity.kt
@@ -1,0 +1,22 @@
+package com.airwallex.paymentacceptance.ui
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+/**
+ * Trampoline activity running in a separate process (":restart").
+ * Survives main process death and relaunches MainActivity to trigger a fresh start.
+ */
+class RestartActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(
+            Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+        )
+        finish()
+    }
+}

--- a/sample/src/main/java/com/airwallex/paymentacceptance/ui/SettingActivity.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/ui/SettingActivity.kt
@@ -1,5 +1,7 @@
 package com.airwallex.paymentacceptance.ui
 
+import android.content.Intent
+import android.os.Process
 import com.airwallex.android.core.AirwallexCheckoutMode
 import com.airwallex.paymentacceptance.R
 import com.airwallex.paymentacceptance.SampleApplication
@@ -56,16 +58,12 @@ class SettingActivity : BasePaymentActivity<ActivitySettingBinding, SettingViewM
         mBinding.etCustomerId.setActionClickListener {
             val selectedEnv = mBinding.selectViewEnvironment.currentOption
             if (selectedEnv != Settings.sdkEnv) {
-                // Environment changed but not saved yet
                 showAlert(
                     "",
-                    "You need to save the new environment first to generate customer id",
-                    positiveButtonText = "Save",
+                    "The app needs to restart before generating customer ID in the new environment.",
+                    positiveButtonText = "Restart",
                     negativeButtonText = "Cancel",
-                    onPositive = {
-                        saveAllSettings()
-                        finish()
-                    }
+                    onPositive = { saveAndRestart() }
                 )
             } else {
                 mViewModel.generateCustomerId()
@@ -76,9 +74,18 @@ class SettingActivity : BasePaymentActivity<ActivitySettingBinding, SettingViewM
             loadCachedValuesForEnvironment(selectedEnv)
         }
         mBinding.btnSave.setOnClickListener {
-            saveAllSettings()
-            showAlert("", "settings saved") {
-                finish()
+            if (mBinding.selectViewEnvironment.currentOption != Settings.sdkEnv) {
+                showAlert(
+                    "",
+                    "The app will restart to apply the new environment."
+                ) {
+                    saveAndRestart()
+                }
+            } else {
+                saveAllSettings()
+                showAlert("", "settings saved") {
+                    finish()
+                }
             }
         }
 
@@ -119,6 +126,12 @@ class SettingActivity : BasePaymentActivity<ActivitySettingBinding, SettingViewM
         }
     }
 
+    private fun saveAndRestart() {
+        saveAllSettings()
+        startActivity(Intent(this, RestartActivity::class.java))
+        Process.killProcess(Process.myPid())
+    }
+
     private fun loadCachedValuesForEnvironment(env: String) {
         mBinding.etCustomerId.setText(Settings.getCachedCustomerIdForEnv(env))
         mBinding.etAPIKey.setText(Settings.getApiKeyForEnv(env))
@@ -151,6 +164,7 @@ class SettingActivity : BasePaymentActivity<ActivitySettingBinding, SettingViewM
         Settings.expressCheckout = if (mBinding.swExpressCheckout.isChecked()) "Enabled" else "Disabled"
         Settings.useSession = if (mBinding.swUseSession.isChecked()) "Enabled" else "Disabled"
         Settings.requiresEmail = if (mBinding.swEmail.isChecked()) "True" else "False"
+        Settings.flush()
     }
 
     override fun getViewBinding(): ActivitySettingBinding {


### PR DESCRIPTION

[Screen_recording_20260424_102810.webm](https://github.com/user-attachments/assets/4071cbba-908f-40a0-9067-fa3f7a8241cb)

## Summary
- Add `RestartActivity` trampoline in a separate process to reliably restart the app when the SDK environment changes, so we can reconfigure the env in AirTracker and Risk SDK
- Flush SharedPreferences synchronously before killing the process to ensure settings persist
- Show distinct alerts for the Save button (single action) and Customer ID generate button (Restart/Cancel)

## Test plan
- [ ] Change environment in settings and tap Save — app restarts and loads with new environment
- [ ] Change environment and tap Generate Customer ID — alert shows with Restart/Cancel options
- [ ] Tap Cancel on the Customer ID alert — no restart, stays on settings screen
- [ ] Save settings without changing environment — saves normally without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)