### PR TITLE
[APAM-687] Add missing risk events for consent payment

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/composables/card/CardCvcTextField.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/card/CardCvcTextField.kt
@@ -50,6 +50,7 @@ fun CardCvcTextField(
     isError: Boolean = false,
     errorMessage: String? = null,
     shape: Shape = OutlinedTextFieldDefaults.shape,
+    riskScreen: String = "page_create_card",
 ) {
     val cvcLength = remember(cardBrand) {
         when (cardBrand) {
@@ -97,9 +98,11 @@ fun CardCvcTextField(
         errorText = errorMessage,
         modifier = modifier
             .onFocusEvent { focusState ->
-                if (focusState.hasFocus && textFieldValue.text.isNotEmpty()) {
-                    showClearButton = true
-                    AirwallexRisk.log(event = "input_card_cvc", screen = "page_create_card")
+                if (focusState.hasFocus) {
+                    if (textFieldValue.text.isNotEmpty()) {
+                        showClearButton = true
+                    }
+                    AirwallexRisk.log(event = "input_card_cvc", screen = riskScreen)
                 }
             }
             .onFocusChanged { focusState ->

--- a/airwallex/src/main/java/com/airwallex/android/view/composables/card/CardSection.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/card/CardSection.kt
@@ -40,6 +40,7 @@ import com.airwallex.android.view.composables.consent.ConsentDetailSection
 import com.airwallex.android.view.composables.consent.ConsentListSection
 import com.airwallex.android.view.util.AnalyticsConstants.PAYMENT_METHOD
 import com.airwallex.android.view.util.AnalyticsConstants.TAP_PAY_BUTTON
+import com.airwallex.risk.AirwallexRisk
 import java.util.Locale
 
 @Suppress("ComplexMethod", "LongMethod", "LongParameterList")
@@ -253,6 +254,7 @@ internal fun CardSection(
                         )
                     },
                     onScreenViewed = {
+                        AirwallexRisk.log(event = "show_consent", screen = "page_consent")
                         addPaymentMethodViewModel.trackScreenViewed(
                             PaymentMethodType.CARD.value,
                             mapOf(Field.SUBTYPE to "consent")
@@ -275,6 +277,7 @@ private fun onCheckoutWithoutCvcOperationStart(
     paymentFlowViewModel: PaymentFlowViewModel,
 ) {
     paymentFlowListener.onLoadingStateChanged(true, airwallex.activity)
+    AirwallexRisk.log(event = "click_payment_button", screen = "page_consent")
     consent.paymentMethod?.type?.let {
         AnalyticsLogger.logAction(TAP_PAY_BUTTON, mapOf(PAYMENT_METHOD to it))
     }
@@ -289,6 +292,7 @@ private fun onCheckoutWithCvcOperationStart(
     paymentFlowViewModel: PaymentFlowViewModel,
 ) {
     paymentFlowListener.onLoadingStateChanged(true, airwallex.activity)
+    AirwallexRisk.log(event = "click_payment_button", screen = "page_consent")
     consent.paymentMethod?.type?.let {
         AnalyticsLogger.logAction(TAP_PAY_BUTTON, mapOf(PAYMENT_METHOD to it))
     }

--- a/airwallex/src/main/java/com/airwallex/android/view/composables/consent/ConsentDetailSection.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/consent/ConsentDetailSection.kt
@@ -39,6 +39,7 @@ internal fun ConsentDetailSection(
     if (isCvcRequired) {
         CardCvcTextField(
             cardBrand = cardBrand,
+            riskScreen = "page_consent",
             onTextChanged = { value ->
                 cvv = value.text
                 cvvErrorMessage = null


### PR DESCRIPTION
## Summary
- Added `show_consent` risk event on `page_consent` screen when consent detail view is displayed
- Added `input_card_cvc` risk event on `page_consent` screen when CVC field gains focus (parameterized `CardCvcTextField` with `riskScreen`)
- Added `click_payment_button` risk event on `page_consent` screen when checkout is triggered (both with and without CVC)
- Fixed `input_card_cvc` not firing when CVC field starts empty (separated risk log from clear button logic)

## Test plan
- [x] Select a saved card consent and verify `show_consent` / `page_consent` is logged
- [x] Tap CVC field on consent detail and verify `input_card_cvc` / `page_consent` is logged
- [x] Tap pay button on consent detail and verify `click_payment_button` / `page_consent` is logged
- [x] Verify `input_card_cvc` / `page_create_card` still works on add card screen
- [ ] Verify no regression on existing risk events

🤖 Generated with [Claude Code](https://claude.com/claude-code)