### PR TITLE
[APAM-678] Add wait time before repository dispatch on release workflow

### DIFF
--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Log version
         run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
+      - name: Wait 20 minutes for Maven Central propagation
+        if: github.event_name == 'workflow_call'
+        run: sleep 1200
       - name: Send repository dispatch to Flutter SDK
         env:
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}


### PR DESCRIPTION
## Summary

- Adds a 20-minute wait step in `repo-dispatch-on-release.yml` before sending repository dispatch events to Flutter and React Native SDKs
- Wait only applies when triggered via `workflow_call` (i.e., chained from `maven.yml` after a release publish)
- Manual `workflow_dispatch` triggers skip the wait and dispatch immediately

## Why

Maven Central propagation after `closeAndReleaseSonatypeStagingRepository` typically takes 10–30 minutes. Without a wait, downstream SDKs may try to resolve the new artifact before it's available on Maven Central, causing build failures.

## Test plan

- [ ] Verify manual `workflow_dispatch` on `repo-dispatch-on-release.yml` dispatches immediately (no wait step executed)
- [ ] Verify next release triggered via `maven.yml` waits 20 minutes before dispatching to Flutter and React Native repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)