### PR TITLE
[APAM-717]: dialog now can pay twice by updating the session in viewmodel

### DIFF
--- a/airwallex/src/main/java/com/airwallex/android/view/PaymentFlowViewModel.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/PaymentFlowViewModel.kt
@@ -1,8 +1,11 @@
 package com.airwallex.android.view
 
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewModelScope
 import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.Airwallex.PaymentResultListener
@@ -18,6 +21,7 @@ import com.airwallex.android.core.model.DisablePaymentConsentParams
 import com.airwallex.android.core.model.PaymentConsent
 import com.airwallex.android.core.model.PaymentMethod
 import com.airwallex.android.core.model.PaymentMethodType
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,7 +41,7 @@ import kotlin.coroutines.resume
  */
 class PaymentFlowViewModel(
     private val airwallex: Airwallex,
-    private val session: AirwallexSession
+    private var session: AirwallexSession
 ) : ViewModel() {
 
     private val _availablePaymentMethods = MutableStateFlow<List<AvailablePaymentMethodType>>(emptyList())
@@ -50,9 +54,12 @@ class PaymentFlowViewModel(
     private val _availablePaymentConsents = MutableStateFlow<List<PaymentConsent>>(emptyList())
     val availablePaymentConsents: StateFlow<List<PaymentConsent>> = _availablePaymentConsents.asStateFlow()
 
-    // Payment flow result event - one-time event stream
+    // Payment flow result event - one-time event stream.
+    // need to ensure only one observer for this channel
     private val _paymentResult = Channel<PaymentResultEvent>(capacity = Channel.CONFLATED)
     val paymentResult: Flow<PaymentResultEvent> = _paymentResult.receiveAsFlow()
+
+    private var resultObserverJob: Job? = null
 
     // Delete payment consent result - one-time event stream
     private val _deleteConsentResult = MutableSharedFlow<DeleteConsentResult>(replay = 0)
@@ -83,6 +90,37 @@ class PaymentFlowViewModel(
 
     fun updateActivity(newActivity: ComponentActivity) {
         airwallex.updateActivity(newActivity)
+    }
+
+    /**
+     * Swap the session this VM operates on. The VM is Activity-scoped, so without
+     * this a second checkout on the same Activity would reuse the factory-injected
+     * session and confirm against an already-completed PaymentIntent. Resets
+     * per-session caches so PaymentSheet refetches methods/consents.
+     */
+    fun updateSession(newSession: AirwallexSession) {
+        if (session === newSession) return
+        session = newSession
+        _availablePaymentMethods.value = emptyList()
+        _originalPaymentConsents.value = emptyList()
+        _availablePaymentConsents.value = emptyList()
+    }
+
+    /**
+     * Subscribe [listener] to [paymentResult], cancelling any previous subscription.
+     * The channel is single-receiver, so a stale collector from a dismissed UI
+     * would otherwise swallow results meant for the current one.
+     */
+    fun observeResults(activity: ComponentActivity, listener: PaymentFlowListener) {
+        resultObserverJob?.cancel()
+        resultObserverJob = activity.lifecycleScope.launch {
+            activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                paymentResult.collect { result ->
+                    listener.onLoadingStateChanged(false, activity)
+                    listener.onPaymentResult(result.status)
+                }
+            }
+        }
     }
 
     /**

--- a/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentElement.kt
+++ b/airwallex/src/main/java/com/airwallex/android/view/composables/PaymentElement.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexSession
@@ -99,8 +97,8 @@ class PaymentElement private constructor(
                 )
             )[PaymentFlowViewModel::class.java]
             viewModel.updateActivity(airwallex.activity)
-
-            observeState(airwallex, viewModel, paymentFlowListener)
+            viewModel.updateSession(session)
+            viewModel.observeResults(airwallex.activity, paymentFlowListener)
 
             val alreadyLoaded = viewModel.availablePaymentMethods.value.isNotEmpty()
 
@@ -331,21 +329,6 @@ class PaymentElement private constructor(
                 paymentFlowListener = paymentFlowListener,
                 flowViewModel = flowViewModel
             )
-        }
-    }
-}
-
-private fun observeState(
-    airwallex: Airwallex,
-    viewModel: PaymentFlowViewModel,
-    paymentFlowListener: PaymentFlowListener
-) {
-    airwallex.activity.lifecycleScope.launch {
-        airwallex.activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            viewModel.paymentResult.collect { result ->
-                paymentFlowListener.onLoadingStateChanged(false, airwallex.activity)
-                paymentFlowListener.onPaymentResult(result.status)
-            }
         }
     }
 }

--- a/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
@@ -1,6 +1,10 @@
 package com.airwallex.android.view
 
+import androidx.activity.ComponentActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentSession
 import com.airwallex.android.core.AirwallexPaymentStatus
@@ -915,6 +919,201 @@ class PaymentFlowViewModelTest {
                 additionalInfo = testAdditionalInfo
             )
         }
+    }
+
+    // ========== updateSession Tests ==========
+
+    @Test
+    fun `updateSession with same instance preserves caches`() = runTest {
+        val session = createPaymentSession()
+        val mockMethods = listOf<AvailablePaymentMethodType>(
+            mockk { every { name } returns "card" }
+        )
+        val mockConsents = listOf(createMockPaymentConsent(id = "c1", fingerprint = "fp1"))
+        coEvery {
+            airwallex.fetchAvailablePaymentMethodsAndConsents(session)
+        } returns Result.success(Pair(mockMethods, mockConsents))
+
+        val viewModel = createViewModel(session)
+        viewModel.fetchAvailablePaymentMethodsAndConsents()
+        advanceUntilIdle()
+        assertEquals(mockMethods, viewModel.availablePaymentMethods.value)
+        assertEquals(1, viewModel.availablePaymentConsents.value.size)
+
+        viewModel.updateSession(session)
+
+        assertEquals(mockMethods, viewModel.availablePaymentMethods.value)
+        assertEquals(1, viewModel.availablePaymentConsents.value.size)
+    }
+
+    @Test
+    fun `updateSession with different instance clears caches`() = runTest {
+        val session = createPaymentSession()
+        val mockMethods = listOf<AvailablePaymentMethodType>(
+            mockk { every { name } returns "card" }
+        )
+        val mockConsents = listOf(createMockPaymentConsent(id = "c1", fingerprint = "fp1"))
+        coEvery {
+            airwallex.fetchAvailablePaymentMethodsAndConsents(session)
+        } returns Result.success(Pair(mockMethods, mockConsents))
+
+        val viewModel = createViewModel(session)
+        viewModel.fetchAvailablePaymentMethodsAndConsents()
+        advanceUntilIdle()
+        assertEquals(mockMethods, viewModel.availablePaymentMethods.value)
+        assertEquals(1, viewModel.availablePaymentConsents.value.size)
+
+        viewModel.updateSession(createPaymentSession())
+
+        assertTrue(viewModel.availablePaymentMethods.value.isEmpty())
+        assertTrue(viewModel.availablePaymentConsents.value.isEmpty())
+    }
+
+    @Test
+    fun `updateSession routes subsequent checkout to new session`() = runTest {
+        val firstSession = createPaymentSession()
+        val secondSession = createPaymentSession()
+        val viewModel = createViewModel(firstSession)
+        val card = mockk<PaymentMethod.Card>(relaxed = true) {
+            every { cvc } returns "123"
+        }
+        val expectedStatus = AirwallexPaymentStatus.Success("intent_2")
+
+        val slot = slot<Airwallex.PaymentResultListener>()
+        coEvery {
+            airwallex.checkout(
+                session = secondSession,
+                paymentMethod = any(),
+                cvc = "123",
+                saveCard = false,
+                listener = capture(slot)
+            )
+        } answers {
+            slot.captured.onCompleted(expectedStatus)
+        }
+
+        viewModel.updateSession(secondSession)
+        val (results, job) = collectFlow(viewModel.paymentResult)
+        viewModel.checkoutWithNewCard(card, saveCard = false, billing = null)
+        advanceUntilIdle()
+
+        assertEquals(expectedStatus, results.first().status)
+        coVerify(exactly = 1) {
+            airwallex.checkout(
+                session = secondSession,
+                paymentMethod = any(),
+                cvc = "123",
+                saveCard = false,
+                listener = any()
+            )
+        }
+        coVerify(exactly = 0) {
+            airwallex.checkout(
+                session = firstSession,
+                paymentMethod = any(),
+                cvc = any(),
+                saveCard = any(),
+                listener = any()
+            )
+        }
+        job.cancel()
+    }
+
+    // ========== observeResults Tests ==========
+
+    @Test
+    fun `observeResults delivers paymentResult to current listener`() = runTest {
+        val session = createPaymentSession()
+        val viewModel = createViewModel(session)
+        val (activity, _) = createTestActivity()
+        val listener = mockk<PaymentFlowListener>(relaxed = true)
+
+        viewModel.observeResults(activity, listener)
+        advanceUntilIdle()
+
+        emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_1"))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { listener.onLoadingStateChanged(false, activity) }
+        verify(exactly = 1) {
+            listener.onPaymentResult(match {
+                it is AirwallexPaymentStatus.Success && it.paymentIntentId == "intent_1"
+            })
+        }
+    }
+
+    @Test
+    fun `observeResults cancels previous subscription so old listener does not receive`() = runTest {
+        val session = createPaymentSession()
+        val viewModel = createViewModel(session)
+        val (activity, _) = createTestActivity()
+        val oldListener = mockk<PaymentFlowListener>(relaxed = true)
+        val newListener = mockk<PaymentFlowListener>(relaxed = true)
+
+        viewModel.observeResults(activity, oldListener)
+        advanceUntilIdle()
+        viewModel.observeResults(activity, newListener)
+        advanceUntilIdle()
+
+        emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_2"))
+        advanceUntilIdle()
+
+        verify(exactly = 0) { oldListener.onPaymentResult(any()) }
+        verify(exactly = 0) { oldListener.onLoadingStateChanged(any(), any()) }
+        verify(exactly = 1) { newListener.onPaymentResult(any()) }
+        verify(exactly = 1) { newListener.onLoadingStateChanged(false, activity) }
+    }
+
+    @Test
+    fun `observeResults is safe with no prior subscription`() = runTest {
+        val session = createPaymentSession()
+        val viewModel = createViewModel(session)
+        val (activity, _) = createTestActivity()
+        val listener = mockk<PaymentFlowListener>(relaxed = true)
+
+        viewModel.observeResults(activity, listener)
+        advanceUntilIdle()
+
+        emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_1"))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { listener.onPaymentResult(any()) }
+    }
+
+    private fun createTestActivity(
+        state: Lifecycle.State = Lifecycle.State.RESUMED
+    ): Pair<ComponentActivity, LifecycleOwner> {
+        val owner = object : LifecycleOwner {
+            val registry = LifecycleRegistry.createUnsafe(this)
+            override val lifecycle: Lifecycle get() = registry
+        }
+        owner.registry.currentState = state
+        val activity = mockk<ComponentActivity>(relaxed = true)
+        every { activity.lifecycle } returns owner.lifecycle
+        return activity to owner
+    }
+
+    private fun emitCheckoutResult(
+        viewModel: PaymentFlowViewModel,
+        session: AirwallexSession,
+        status: AirwallexPaymentStatus
+    ) {
+        val card = mockk<PaymentMethod.Card>(relaxed = true) {
+            every { cvc } returns "123"
+        }
+        val slot = slot<Airwallex.PaymentResultListener>()
+        coEvery {
+            airwallex.checkout(
+                session = session,
+                paymentMethod = any(),
+                cvc = "123",
+                saveCard = false,
+                listener = capture(slot)
+            )
+        } answers {
+            slot.captured.onCompleted(status)
+        }
+        viewModel.checkoutWithNewCard(card, saveCard = false, billing = null)
     }
 
     @Test

--- a/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
@@ -1036,9 +1036,11 @@ class PaymentFlowViewModelTest {
 
         verify(exactly = 1) { listener.onLoadingStateChanged(false, activity) }
         verify(exactly = 1) {
-            listener.onPaymentResult(match {
-                it is AirwallexPaymentStatus.Success && it.paymentIntentId == "intent_1"
-            })
+            listener.onPaymentResult(
+                match {
+                    it is AirwallexPaymentStatus.Success && it.paymentIntentId == "intent_1"
+                }
+            )
         }
     }
 

--- a/components-core/src/main/java/com/airwallex/android/core/http/AirwallexHttpResponse.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/http/AirwallexHttpResponse.kt
@@ -39,6 +39,6 @@ data class AirwallexHttpResponse internal constructor(
     }
 
     private companion object {
-        private const val TRACE_ID_HEADER = "x-awx-traceid"
+        private const val TRACE_ID_HEADER = "x-b3-traceid"
     }
 }


### PR DESCRIPTION
Issue
dialog always use existing payment intent. and even if not, there will be 2 loading progress appears and it's non cancellable on the 2nd payment

Root cause
  Both bugs trace back to one decision: PaymentFlowViewModel is Activity-scoped via ViewModelProvider(airwallex.activity, ...). this causes new Session to be ignored and use old Session instead when creating PaymentElement twice under same activity. and `create` will collect `paymentResult`, which means on 2nd payment there will be 2 collections for 1 Channel. so there will be 2 loading progress but only 1 of them will get the newest result

Solution
add updateSession in PaymentFlowViewModel and ensure there's only 1 observer of Channel by cancelling the previous one.

additional small fix: change traceid header for logging