### PR TITLE
fix: replace event-based wait condition with explicit wait_minutes input [skip ci]

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,21 @@ jobs:
   maven:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout project
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # 3.6.0
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            VERSION=$(sed -nE "s/version = '([0-9.]+)'/\1/p" build.gradle)
+            echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up our JDK environment
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 #3.14.1
@@ -41,5 +53,6 @@ jobs:
     needs: maven
     uses: ./.github/workflows/repo-dispatch-on-release.yml
     with:
-      tag: ${{ github.event.release.tag_name }}
+      tag: ${{ needs.maven.outputs.tag }}
+      wait_minutes: 20
     secrets: inherit

--- a/.github/workflows/repo-dispatch-on-release.yml
+++ b/.github/workflows/repo-dispatch-on-release.yml
@@ -7,12 +7,22 @@ on:
         description: 'Android SDK version (e.g., 6.3.0)'
         required: true
         type: string
+      wait_minutes:
+        description: 'Minutes to wait before dispatching (0 to skip)'
+        required: false
+        type: number
+        default: 0
   workflow_dispatch:
     inputs:
       tag:
         description: 'Android SDK version (e.g., 6.3.0)'
         required: true
         type: string
+      wait_minutes:
+        description: 'Minutes to wait before dispatching (0 to skip)'
+        required: false
+        type: number
+        default: 0
 
 jobs:
   repo-dispatch-on-release:
@@ -20,9 +30,9 @@ jobs:
     steps:
       - name: Log version
         run: 'echo "Dispatching for version: ${{ inputs.tag }}"'
-      - name: Wait 20 minutes for Maven Central propagation
-        if: github.event_name == 'workflow_call'
-        run: sleep 1200
+      - name: Wait for Maven Central propagation
+        if: inputs.wait_minutes > 0
+        run: sleep ${{ fromJSON(inputs.wait_minutes) * 60 }}
       - name: Send repository dispatch to Flutter SDK
         env:
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_PAT }}


### PR DESCRIPTION
The previous condition (`github.event_name == 'workflow_call'`) never evaluated to true because `github.event_name` in a reusable workflow reflects the caller's triggering event, not `workflow_call`.

Replaced with an explicit `wait_minutes` input so callers control the wait duration. `maven.yml` now determines the version tag from the release event or `build.gradle` (for manual `workflow_dispatch` runs) and passes it as a job output to the repo-dispatch job.