### PR TITLE
fix: more handling in case args cleared by system

### DIFF
--- a/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayLauncherActivity.kt
+++ b/googlepay/src/main/java/com/airwallex/android/googlepay/GooglePayLauncherActivity.kt
@@ -9,7 +9,7 @@ import com.airwallex.android.core.extension.putIfNotNull
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.AnalyticsLogger.Field
-import com.airwallex.android.ui.extension.getExtraArgs
+import com.airwallex.android.ui.extension.getExtraArgsOrNull
 import com.airwallex.risk.AirwallexRisk
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.wallet.AutoResolveHelper
@@ -22,12 +22,12 @@ class GooglePayLauncherActivity : ComponentActivity() {
     private val viewModel: GooglePayLauncherViewModel by lazy {
         ViewModelProvider(
             this,
-            GooglePayLauncherViewModel.Factory(application, args)
+            GooglePayLauncherViewModel.Factory(application, requireNotNull(args))
         )[GooglePayLauncherViewModel::class.java]
     }
 
-    private val args: GooglePayActivityLaunch.Args by lazy {
-        intent.getExtraArgs()
+    private val args: GooglePayActivityLaunch.Args? by lazy {
+        intent.getExtraArgsOrNull()
     }
 
     private val googlePayLauncher = registerForActivityResult(GetPaymentDataResult()) {
@@ -36,6 +36,17 @@ class GooglePayLauncherActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (args == null) {
+            // Launch args were null after process death — fail the activity
+            // instead of crashing so the merchant gets a Cancel result.
+            AirwallexLogger.error("GooglePayLauncherActivity: missing args, finishing")
+            AnalyticsLogger.logError(
+                "googlepay_launcher_init_failed",
+                mapOf("activity" to "GooglePayLauncherActivity"),
+            )
+            finishWithResult(GooglePayActivityLaunch.Result.Cancel)
+            return
+        }
         AirwallexRisk.log(event = "show_google_pay", screen = "page_google_pay")
         val task = viewModel.getLoadPaymentDataTask()
         task.addOnCompleteListener(googlePayLauncher::launch)

--- a/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityActivity.kt
+++ b/security-3ds/src/main/java/com/airwallex/android/threedsecurity/ThreeDSecurityActivity.kt
@@ -1,7 +1,6 @@
 package com.airwallex.android.threedsecurity
 
 import android.content.Intent
-import android.os.Bundle
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
 import com.airwallex.android.core.Airwallex
@@ -42,8 +41,8 @@ class ThreeDSecurityActivity : AirwallexActivity() {
         return R.drawable.airwallex_ic_close
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun initView() {
+        super.initView()
 
         val client = ThreeDSecureWebViewClient(
             { lifecycleScope },

--- a/ui-core/src/main/java/com/airwallex/android/ui/AirwallexActivity.kt
+++ b/ui-core/src/main/java/com/airwallex/android/ui/AirwallexActivity.kt
@@ -1,6 +1,5 @@
 package com.airwallex.android.ui
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewStub

--- a/ui-core/src/main/java/com/airwallex/android/ui/AirwallexActivity.kt
+++ b/ui-core/src/main/java/com/airwallex/android/ui/AirwallexActivity.kt
@@ -1,5 +1,6 @@
 package com.airwallex.android.ui
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewStub
@@ -39,6 +40,21 @@ abstract class AirwallexActivity : AppCompatActivity(), AirwallexInternalActivit
     companion object {
         private const val KEY_IS_LOADING = "airwallex_is_loading"
         private const val KEY_LOADING_CANCELABLE = "airwallex_loading_cancelable"
+        private const val KEY_LAUNCH_BUNDLE = "airwallex_launch_bundle"
+        internal const val EVENT_INIT_FAILED = "activity_init_failed"
+    }
+
+    /**
+     * Restore the launch bundle from savedInstanceState back into the intent so
+     * args lazy reads succeed after process death. Idempotent — only restores if
+     * the intent doesn't already carry the bundle.
+     */
+    protected fun restoreLaunchBundleIfNeeded(savedInstanceState: Bundle?) {
+        if (savedInstanceState == null) return
+        if (intent.hasExtra(AirwallexActivityLaunch.Args.AIRWALLEX_BUNDLE_EXTRA)) return
+        savedInstanceState.getBundle(KEY_LAUNCH_BUNDLE)?.let { launchBundle ->
+            intent.putExtra(AirwallexActivityLaunch.Args.AIRWALLEX_BUNDLE_EXTRA, launchBundle)
+        }
     }
 
     abstract fun onBackButtonPressed()
@@ -68,19 +84,34 @@ abstract class AirwallexActivity : AppCompatActivity(), AirwallexInternalActivit
     open fun addObserver() = Unit
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        restoreLaunchBundleIfNeeded(savedInstanceState)
         super.onCreate(savedInstanceState)
-        setContentView(viewBinding.root)
-        initView()
-        addListener()
-        addObserver()
+        try {
+            setContentView(viewBinding.root)
+            initView()
+            addListener()
+            addObserver()
 
-        // Restore loading dialog state after configuration change
-        savedInstanceState?.let {
-            isLoadingBeforeConfigChange = it.getBoolean(KEY_IS_LOADING, false)
-            loadingCancelable = it.getBoolean(KEY_LOADING_CANCELABLE, true)
-            if (isLoadingBeforeConfigChange) {
-                setLoadingProgress(loading = true, cancelable = loadingCancelable)
+            // Restore loading dialog state after configuration change
+            savedInstanceState?.let {
+                isLoadingBeforeConfigChange = it.getBoolean(KEY_IS_LOADING, false)
+                loadingCancelable = it.getBoolean(KEY_LOADING_CANCELABLE, true)
+                if (isLoadingBeforeConfigChange) {
+                    setLoadingProgress(loading = true, cancelable = loadingCancelable)
+                }
             }
+        } catch (e: IllegalArgumentException) {
+            // Required launch args were null — typically because the launch
+            // Intent's nested parcelable failed to re-marshal after process
+            // death. Fail the activity instead of crashing the host app so the
+            // merchant gets RESULT_CANCELED and can recover.
+            AirwallexLogger.error("$localClassName: init failed, finishing", e)
+            AnalyticsLogger.logError(
+                EVENT_INIT_FAILED,
+                mapOf("activity" to localClassName),
+            )
+            setResult(RESULT_CANCELED)
+            finish()
         }
     }
 
@@ -89,6 +120,11 @@ abstract class AirwallexActivity : AppCompatActivity(), AirwallexInternalActivit
         // Save loading dialog state before configuration change
         outState.putBoolean(KEY_IS_LOADING, loading)
         outState.putBoolean(KEY_LOADING_CANCELABLE, loadingCancelable)
+        // Backup the launch bundle so process-death recreation can recover args
+        // even if the framework loses the inner parcelable.
+        intent.getBundleExtra(AirwallexActivityLaunch.Args.AIRWALLEX_BUNDLE_EXTRA)?.let {
+            outState.putBundle(KEY_LAUNCH_BUNDLE, it)
+        }
     }
 
     override fun onDestroy() {

--- a/ui-core/src/main/java/com/airwallex/android/ui/checkout/AirwallexCheckoutBaseActivity.kt
+++ b/ui-core/src/main/java/com/airwallex/android/ui/checkout/AirwallexCheckoutBaseActivity.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import com.airwallex.android.core.Airwallex
 import com.airwallex.android.core.AirwallexPaymentStatus
 import com.airwallex.android.core.AirwallexSession
+import com.airwallex.android.core.log.AirwallexLogger
+import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.model.*
 import com.airwallex.android.ui.AirwallexActivity
 
@@ -26,8 +28,26 @@ abstract class AirwallexCheckoutBaseActivity : AirwallexActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Update the Airwallex instance in the ViewModel to ensure it always refers to the current Activity
-        viewModel.updateActivity(this)
+        // Restore the launch bundle into intent first so the args lazy that
+        // viewModel depends on can resolve after process death.
+        restoreLaunchBundleIfNeeded(savedInstanceState)
+        try {
+            // Update the Airwallex instance in the ViewModel to ensure it always
+            // refers to the current Activity. This triggers args lazy resolution
+            // via the Factory's session parameter, so it can throw if args are
+            // missing — handle that here to keep the host app alive.
+            viewModel.updateActivity(this)
+        } catch (e: IllegalArgumentException) {
+            AirwallexLogger.error("$localClassName: viewModel init failed, finishing", e)
+            AnalyticsLogger.logError(
+                EVENT_INIT_FAILED,
+                mapOf("activity" to localClassName),
+            )
+            super.onCreate(savedInstanceState)
+            setResult(RESULT_CANCELED)
+            finish()
+            return
+        }
         super.onCreate(savedInstanceState)
     }
 

--- a/ui-core/src/main/java/com/airwallex/android/ui/extension/Intent+Extensions.kt
+++ b/ui-core/src/main/java/com/airwallex/android/ui/extension/Intent+Extensions.kt
@@ -4,24 +4,30 @@ import android.content.Intent
 import android.os.Build
 import com.airwallex.android.ui.AirwallexActivityLaunch
 
-inline fun <reified T> Intent.getExtraArgs(): T {
-    return getBundleExtra(AirwallexActivityLaunch.Args.AIRWALLEX_BUNDLE_EXTRA).let {
-        requireNotNull(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                it?.getParcelable(AirwallexActivityLaunch.Args.AIRWALLEX_EXTRA, T::class.java)
-            } else {
-                it?.getParcelable(AirwallexActivityLaunch.Args.AIRWALLEX_EXTRA)
-            }
-        )
+inline fun <reified T> Intent.getExtraArgs(): T = requireNotNull(getExtraArgsOrNull())
+
+inline fun <reified T> Intent.getExtraArgsOrNull(): T? {
+    val bundle = getBundleExtra(AirwallexActivityLaunch.Args.AIRWALLEX_BUNDLE_EXTRA) ?: return null
+    // After process death the framework re-marshals the launch Intent without
+    // attaching the app classloader to nested bundles, so getParcelable silently
+    // returns null. Set it explicitly before reading.
+    bundle.classLoader = T::class.java.classLoader
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        bundle.getParcelable(AirwallexActivityLaunch.Args.AIRWALLEX_EXTRA, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        bundle.getParcelable(AirwallexActivityLaunch.Args.AIRWALLEX_EXTRA)
     }
 }
 
-inline fun <reified T> Intent.getExtraResult(): T {
-    return requireNotNull(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            getParcelableExtra(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA, T::class.java)
-        } else {
-            getParcelableExtra(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA)
-        }
-    )
+inline fun <reified T> Intent.getExtraResult(): T = requireNotNull(getExtraResultOrNull())
+
+inline fun <reified T> Intent.getExtraResultOrNull(): T? {
+    setExtrasClassLoader(T::class.java.classLoader)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(AirwallexActivityLaunch.Result.AIRWALLEX_EXTRA)
+    }
 }


### PR DESCRIPTION
**Issue**
Args in AirwallexActivity is null, but it requiresNonNull
**Root cause**
Hard to reproduce but most likely OS kills the process when it's in background. but there are 2 potential issues:
1. When the OS kills the app process and recreates the activity from the saved launch Intent, Android re-marshals the Intent across the process boundary. The outer extras Bundle gets the app classloader attached automatically, but the inner Bundle returned by intent.getBundleExtra(...) does not inherit it. Its classLoader field is null.
When getParcelable(...) then tries to find AddPaymentMethodActivityLaunch.Args.CREATOR, it falls back to the system bootclasspath classloader, which doesn't know about app classes. Class.forName throws ClassNotFoundException, Bundle silently catches it and returns null, and our requireNotNull then throws.

**Solution**
  1. Classloader fix — Intent+Extensions.kt
  Set the inner bundle's classloader explicitly before reading the parcelable. Also added getExtraArgsOrNull / getExtraResultOrNull variants for callers that want to handle null themselves. 
  2. onSaveInstanceState backup — AirwallexActivity.kt
  Persist the launch bundle in onSaveInstanceState because data here is  more reliably preserved than launch-Intent extras.
  3. Soft-fail. If args are still null for any reason, log to AnalyticsLogger and finish with RESULT_CANCELED instead of crashing the host app.