### PR TITLE
[APAM-723]: add crash detection & logger only for SDK crash

### DIFF
--- a/.maestro/Card/flow_embedded_element_accordion_payment.yaml
+++ b/.maestro/Card/flow_embedded_element_accordion_payment.yaml
@@ -20,10 +20,22 @@ env:
 - tapOn: "Embedded element"
 # Wait for the embedded element activity to load
 - assertVisible: "Order details"
-# Assert Google Pay button exists by checking for the "Or pay with" divider
-- scrollUntilVisible:
-    element:
+# Assert Google Pay button exists by checking for the "Or pay with" divider.
+# First wait up to 10s for it to render (handles slow Google Pay readiness check),
+# only fall back to scrolling if it still isn't on screen.
+- extendedWaitUntil:
+    visible:
       text: "Or pay with"
+    timeout: 10000
+    optional: true
+- runFlow:
+    when:
+      notVisible:
+        text: "Or pay with"
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: "Or pay with"
 # Scroll down to the card information section
 - scrollUntilVisible:
     element: "Card information"
@@ -68,10 +80,22 @@ env:
 - tapOn: "Embedded element"
 # Wait for the embedded element activity to load
 - assertVisible: "Order details"
-# Assert Google Pay button exists by checking for the "Or pay with" divider
-- scrollUntilVisible:
-    element:
+# Assert Google Pay button exists by checking for the "Or pay with" divider.
+# First wait up to 10s for it to render (handles slow Google Pay readiness check),
+# only fall back to scrolling if it still isn't on screen.
+- extendedWaitUntil:
+    visible:
       text: "Or pay with"
+    timeout: 10000
+    optional: true
+- runFlow:
+    when:
+      notVisible:
+        text: "Or pay with"
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: "Or pay with"
 # Scroll down to see if there are saved cards
 - scrollUntilVisible:
     element: "Choose a card"

--- a/.maestro/Card/flow_embedded_element_tab_payment.yaml
+++ b/.maestro/Card/flow_embedded_element_tab_payment.yaml
@@ -18,10 +18,22 @@ appId: com.airwallex.paymentacceptance
 - tapOn: "Embedded element"
 # Wait for the embedded element activity to load
 - assertVisible: "Order details"
-# Assert Google Pay button exists by checking for the "Or pay with" divider
-- scrollUntilVisible:
-    element:
+# Assert Google Pay button exists by checking for the "Or pay with" divider.
+# First wait up to 10s for it to render (handles slow Google Pay readiness check),
+# only fall back to scrolling if it still isn't on screen.
+- extendedWaitUntil:
+    visible:
       text: "Or pay with"
+    timeout: 10000
+    optional: true
+- runFlow:
+    when:
+      notVisible:
+        text: "Or pay with"
+    commands:
+      - scrollUntilVisible:
+          element:
+            text: "Or pay with"
 # Scroll down to the card information section
 - scrollUntilVisible:
     element: "Card information"

--- a/.maestro/Common/flow_handle_redirect.yaml
+++ b/.maestro/Common/flow_handle_redirect.yaml
@@ -2,7 +2,7 @@ appId: com.airwallex.paymentacceptance
 ---
 # Wait for WebView to load before checking conditionals (they are instant checks, not polls)
 - extendedWaitUntil:
-    visible: "Use without an account|Authorize Now|Pay Now"
+    visible: "Use without an account|Authorize Now|Pay Now|Confirm"
     timeout: 20000
 # WebView opens - handle Chrome sign-in prompt if it appears
 - runFlow:
@@ -10,6 +10,29 @@ appId: com.airwallex.paymentacceptance
       visible: "Use without an account"
     commands:
       - tapOn: "Use without an account"
+# New sandbox UI: "Action" dropdown + "Confirm" button (e.g. AlipayHK)
+# Distinguishes from legacy UI by checking the "Action" label is visible.
+- runFlow:
+    when:
+      visible: "Action"
+      notVisible: "Pay Now|Authorize Now"
+    commands:
+      - tapOn:
+          id: "react-select-2-input"
+      - tapOn: "^Pay$"
+      - tapOn: "Confirm"
+      - extendedWaitUntil:
+          visible: "Return to Merchant|SUCCEED"
+          timeout: 30000
+      - runFlow:
+          when:
+            visible: "^Return to Merchant$"
+          commands:
+            - tapOn: "^Return to Merchant$"
+      - extendedWaitUntil:
+          visible: "SUCCEED"
+          timeout: 30000
+      - tapOn: "OK"
 # Handle two different redirect flows:
 # 1. One-off payment: "Pay Now" button (no checkbox)
 # 2. Recurring/RecurringWithIntent: "Authorize Now" button (with checkbox)

--- a/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
+++ b/airwallex/src/test/java/com/airwallex/android/view/PaymentFlowViewModelTest.kt
@@ -1045,37 +1045,42 @@ class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `observeResults cancels previous subscription so old listener does not receive`() = runTest {
-        val session = createPaymentSession()
-        val viewModel = createViewModel(session)
-        val (activity, _) = createTestActivity()
-        val oldListener = mockk<PaymentFlowListener>(relaxed = true)
-        val newListener = mockk<PaymentFlowListener>(relaxed = true)
+    fun `observeResults cancels previous subscription so old listener does not receive`() =
+        // Share the scheduler with Main so advanceUntilIdle drains lifecycleScope launches too —
+        // otherwise the old subscriber's cancellation may not propagate before the second emit.
+        runTest(testDispatcher) {
+            val session = createPaymentSession()
+            val viewModel = createViewModel(session)
+            val (activity, _) = createTestActivity()
+            val oldListener = mockk<PaymentFlowListener>(relaxed = true)
+            val newListener = mockk<PaymentFlowListener>(relaxed = true)
+            val resultObserverJobField = PaymentFlowViewModel::class.java
+                .getDeclaredField("resultObserverJob").apply { isAccessible = true }
 
-        // Subscribe oldListener and confirm it's actually wired up by emitting first.
-        // This avoids the cancel-vs-emit race: by the time we swap listeners the
-        // channel is drained, so any later miss is unambiguously due to cancellation.
-        viewModel.observeResults(activity, oldListener)
-        advanceUntilIdle()
-        emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_1"))
-        advanceUntilIdle()
-        verify(exactly = 1) { oldListener.onPaymentResult(any()) }
+            // Subscribe oldListener and prove it's wired up by delivering the first event.
+            viewModel.observeResults(activity, oldListener)
+            advanceUntilIdle()
+            val oldJob = resultObserverJobField.get(viewModel) as Job
+            emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_1"))
+            advanceUntilIdle()
+            verify(exactly = 1) { oldListener.onPaymentResult(any()) }
 
-        // Swap to newListener — this must cancel the old subscription.
-        viewModel.observeResults(activity, newListener)
-        advanceUntilIdle()
+            // Swap to newListener — this cancels oldJob. Join it so the channel receiver
+            // is fully unregistered before we emit again (eliminates the cancel-vs-send race).
+            viewModel.observeResults(activity, newListener)
+            oldJob.join()
+            advanceUntilIdle()
 
-        emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_2"))
-        advanceUntilIdle()
+            emitCheckoutResult(viewModel, session, AirwallexPaymentStatus.Success("intent_2"))
+            advanceUntilIdle()
 
-        // Old listener's count is unchanged from the first emission.
-        verify(exactly = 1) { oldListener.onPaymentResult(any()) }
-        verify(exactly = 1) { newListener.onPaymentResult(any()) }
-        verify(exactly = 1) { newListener.onLoadingStateChanged(false, activity) }
-    }
+            verify(exactly = 1) { oldListener.onPaymentResult(any()) }
+            verify(exactly = 1) { newListener.onPaymentResult(any()) }
+            verify(exactly = 1) { newListener.onLoadingStateChanged(false, activity) }
+        }
 
     @Test
-    fun `observeResults is safe with no prior subscription`() = runTest {
+    fun `observeResults is safe with no prior subscription`() = runTest(testDispatcher) {
         val session = createPaymentSession()
         val viewModel = createViewModel(session)
         val (activity, _) = createTestActivity()

--- a/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/Airwallex.kt
@@ -22,6 +22,7 @@ import com.airwallex.android.core.extension.createCardPaymentMethod
 import com.airwallex.android.core.log.AirwallexLogger
 import com.airwallex.android.core.log.AnalyticsLogger
 import com.airwallex.android.core.log.AnalyticsLogger.Field
+import com.airwallex.android.core.log.Crasher
 import com.airwallex.android.core.model.AirwallexPaymentRequest
 import com.airwallex.android.core.model.AirwallexPaymentRequestFlow
 import com.airwallex.android.core.model.AvailablePaymentMethodType
@@ -2279,6 +2280,7 @@ class Airwallex internal constructor(
                 configuration.enableLogging,
                 configuration.saveLogToLocal
             )
+            Crasher.initialize()
             AirwallexLogger.debug("Airwallex SDK v${BuildConfigHelper.versionName} initialized")
             AirwallexLogger.debug("Current connected domain: ${configuration.environment.baseUrl()}")
             AirwallexRisk.start(

--- a/components-core/src/main/java/com/airwallex/android/core/log/Crasher.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/log/Crasher.kt
@@ -1,0 +1,68 @@
+package com.airwallex.android.core.log
+
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlin.system.exitProcess
+
+/**
+ * Uncaught exception handler that logs crashes originating inside the Airwallex SDK
+ * and forwards the exception to the previously installed default handler.
+ *
+ * Crashes whose root cause originated outside the SDK (e.g. in the host app) are
+ * passed through untouched so we don't pollute analytics with merchant-side bugs.
+ */
+object Crasher : Thread.UncaughtExceptionHandler {
+
+    private const val SDK_PACKAGE_PREFIX = "com.airwallex.android."
+    private const val EXIT_DELAY_MILLIS = 1000L
+
+    private var defaultHandler: Thread.UncaughtExceptionHandler? = null
+    private var initialized = false
+
+    fun initialize() {
+        if (initialized) return
+        initialized = true
+        defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler(this)
+    }
+
+    override fun uncaughtException(thread: Thread, throwable: Throwable) {
+        if (originatedInSdk(throwable)) {
+            val errorMessage = throwable.message ?: "No error message available"
+            AirwallexLogger.info("==================Crash detected==================")
+            AirwallexLogger.error("Crash thread: ${thread.name}")
+            AirwallexLogger.error("Crash message: $errorMessage")
+            AirwallexLogger.error(getStackTrace(throwable))
+            AnalyticsLogger.logError("crash", mapOf("message" to errorMessage))
+
+            // Give the IO log writer time to flush before the process is killed.
+            try {
+                Thread.sleep(EXIT_DELAY_MILLIS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            defaultHandler?.uncaughtException(thread, throwable)
+            exitProcess(2)
+        } else {
+            defaultHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun originatedInSdk(throwable: Throwable): Boolean {
+        var rootCause: Throwable = throwable
+        val seen = mutableSetOf(rootCause)
+        while (true) {
+            val next = rootCause.cause ?: break
+            if (!seen.add(next)) break
+            rootCause = next
+        }
+        val topClassName = rootCause.stackTrace.firstOrNull()?.className ?: return false
+        return topClassName.startsWith(SDK_PACKAGE_PREFIX)
+    }
+
+    private fun getStackTrace(throwable: Throwable): String {
+        val stringWriter = StringWriter()
+        throwable.printStackTrace(PrintWriter(stringWriter))
+        return stringWriter.toString()
+    }
+}

--- a/components-core/src/main/java/com/airwallex/android/core/log/Crasher.kt
+++ b/components-core/src/main/java/com/airwallex/android/core/log/Crasher.kt
@@ -49,13 +49,8 @@ object Crasher : Thread.UncaughtExceptionHandler {
     }
 
     private fun originatedInSdk(throwable: Throwable): Boolean {
-        var rootCause: Throwable = throwable
-        val seen = mutableSetOf(rootCause)
-        while (true) {
-            val next = rootCause.cause ?: break
-            if (!seen.add(next)) break
-            rootCause = next
-        }
+        val seen = mutableSetOf(throwable)
+        val rootCause = generateSequence(throwable) { it.cause?.takeIf(seen::add) }.last()
         val topClassName = rootCause.stackTrace.firstOrNull()?.className ?: return false
         return topClassName.startsWith(SDK_PACKAGE_PREFIX)
     }

--- a/components-core/src/test/java/com/airwallex/android/core/log/CrasherTest.kt
+++ b/components-core/src/test/java/com/airwallex/android/core/log/CrasherTest.kt
@@ -1,0 +1,112 @@
+package com.airwallex.android.core.log
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CrasherTest {
+
+    private lateinit var defaultHandler: Thread.UncaughtExceptionHandler
+
+    @Before
+    fun setUp() {
+        mockkObject(AirwallexLogger)
+        mockkObject(AnalyticsLogger)
+        every { AirwallexLogger.info(any()) } returns Unit
+        every { AirwallexLogger.error(any<String>(), any()) } returns Unit
+        every { AnalyticsLogger.logError(any<String>(), any<Map<String, Any>>()) } returns Unit
+
+        defaultHandler = io.mockk.mockk(relaxed = true)
+        // Inject our mock as the default handler that Crasher delegates to.
+        val field = Crasher::class.java.getDeclaredField("defaultHandler").apply { isAccessible = true }
+        field.set(Crasher, defaultHandler)
+        val initField = Crasher::class.java.getDeclaredField("initialized").apply { isAccessible = true }
+        initField.setBoolean(Crasher, true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `originatedInSdk returns true when top frame is SDK class`() {
+        val throwable = throwableWithTopClass("com.airwallex.android.core.Foo")
+        assertTrue(invokeOriginatedInSdk(throwable))
+    }
+
+    @Test
+    fun `originatedInSdk returns false when top frame is non-SDK class`() {
+        val throwable = throwableWithTopClass("com.merchant.app.Bar")
+        assertFalse(invokeOriginatedInSdk(throwable))
+    }
+
+    @Test
+    fun `originatedInSdk walks cause chain to root`() {
+        val rootCause = throwableWithTopClass("com.airwallex.android.card.Baz")
+        val middle = RuntimeException("middle", rootCause)
+        val outer = RuntimeException("outer", middle)
+        assertTrue(invokeOriginatedInSdk(outer))
+    }
+
+    @Test
+    fun `originatedInSdk handles cyclic cause chain without infinite loop`() {
+        val a = MutableCauseThrowable("a").apply {
+            stackTrace = arrayOf(StackTraceElement("com.airwallex.android.core.Cycle", "m", "F.kt", 1))
+        }
+        val b = MutableCauseThrowable("b")
+        a.mutableCause = b
+        b.mutableCause = a
+        // Reaching this assertion proves the walk terminated.
+        invokeOriginatedInSdk(a)
+    }
+
+    @Test
+    fun `originatedInSdk returns false when stack trace is empty`() {
+        val throwable = RuntimeException("empty").apply { stackTrace = emptyArray() }
+        assertFalse(invokeOriginatedInSdk(throwable))
+    }
+
+    @Test
+    fun `uncaughtException passes through non-SDK exceptions without logging`() {
+        val thread = Thread.currentThread()
+        val throwable = throwableWithTopClass("com.merchant.app.Bar")
+
+        Crasher.uncaughtException(thread, throwable)
+
+        verify(exactly = 1) { defaultHandler.uncaughtException(thread, throwable) }
+        verify(exactly = 0) { AnalyticsLogger.logError(any<String>(), any<Map<String, Any>>()) }
+    }
+
+    @Test
+    fun `initialize is idempotent`() {
+        val before = Thread.getDefaultUncaughtExceptionHandler()
+        Crasher.initialize()
+        assertEquals(before, Thread.getDefaultUncaughtExceptionHandler())
+    }
+
+    private fun throwableWithTopClass(className: String, message: String = "boom"): Throwable {
+        return RuntimeException(message).apply {
+            stackTrace = arrayOf(StackTraceElement(className, "method", "File.kt", 10))
+        }
+    }
+
+    private fun invokeOriginatedInSdk(throwable: Throwable): Boolean {
+        val method = Crasher::class.java.getDeclaredMethod("originatedInSdk", Throwable::class.java)
+            .apply { isAccessible = true }
+        return method.invoke(Crasher, throwable) as Boolean
+    }
+
+    private open class MutableCauseThrowable(message: String) : RuntimeException(message) {
+        var mutableCause: Throwable? = null
+        override val cause: Throwable?
+            get() = mutableCause
+    }
+}

--- a/sonar.gradle
+++ b/sonar.gradle
@@ -97,6 +97,7 @@ sonarqube {
                 '**/*EditText.kt',
                 '**/EditTextColorUtil.kt',
                 '**/SessionUtils.kt',
+                '**/log/Crasher.kt',
                 '**/view/CardWidget.kt',
                 '**/paymentacceptance/**',
                 '**/sample/**',


### PR DESCRIPTION
Create additional logger specifically for detecting crash. But ensuring only crashes that happens inside SDK files will be recorded.
Simulated situation where 1 button causes crash in sample mainActivity and the other crash calls a function in Airwallex.kt

https://github.com/user-attachments/assets/2892f420-7907-4efd-a690-3bf295536f11

