### PR TITLE
[APAM-694] Upgrade WeChat SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
 
     kotlinCoroutinesVersion = '1.8.1'
 
-    wechatPayVersion = "6.8.0"
+    wechatPayVersion = "6.8.34"
 
     junitVersion = '4.13.2'
     robolectricVersion = '4.14.1'

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+install:
+  - ./gradlew publishToMavenLocal -x test

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk17
 install:
-  - ./gradlew publishToMavenLocal -x test
+  - ./gradlew publishLocalAll publishToMavenLocal -x test

--- a/sample/src/main/java/com/airwallex/paymentacceptance/Constant.kt
+++ b/sample/src/main/java/com/airwallex/paymentacceptance/Constant.kt
@@ -16,7 +16,6 @@ val products = listOf(
         .setSku("piece")
         .setType("White")
         .setUnitPrice(500.00)
-        .setUrl("www.aircross.com")
         .setQuantity(1)
         .build(),
     PhysicalProduct.Builder()
@@ -26,7 +25,6 @@ val products = listOf(
         .setSku("piece")
         .setType("White")
         .setUnitPrice(500.00)
-        .setUrl("www.aircross.com")
         .setQuantity(1)
         .build()
 )

--- a/wechat/build.gradle
+++ b/wechat/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api project(':security-3ds')
 
     // WeChat Pay
-    implementation "com.tencent.mm.opensdk:wechat-sdk-android-without-mta:$wechatPayVersion"
+    implementation "com.tencent.mm.opensdk:wechat-sdk-android:$wechatPayVersion"
 
     // test
     testImplementation "junit:junit:$junitVersion"

--- a/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
+++ b/wechat/src/test/java/com/airwallex/wechat/WeChatComponentTest.kt
@@ -107,6 +107,7 @@ class WeChatComponentTest {
 
     @Test
     fun `test handleIntent when WeChat response is ok`() {
+        every { component["initiateWeChatPay"](any<WeChat>()) } returns true
         val eventHandler = slot<IWXAPIEventHandler>()
         val response = PayResp()
         response.errCode = BaseResp.ErrCode.ERR_OK
@@ -122,6 +123,7 @@ class WeChatComponentTest {
 
     @Test
     fun `test handleIntent when WeChat response is user cancel`() {
+        every { component["initiateWeChatPay"](any<WeChat>()) } returns true
         val eventHandler = slot<IWXAPIEventHandler>()
         val response = PayResp()
         response.errCode = BaseResp.ErrCode.ERR_USER_CANCEL
@@ -137,6 +139,7 @@ class WeChatComponentTest {
 
     @Test
     fun `test handleIntent when WeChat response is other error`() {
+        every { component["initiateWeChatPay"](any<WeChat>()) } returns true
         val eventHandler = slot<IWXAPIEventHandler>()
         val response = PayResp()
         response.errCode = BaseResp.ErrCode.ERR_COMM


### PR DESCRIPTION
The `wechat-sdk-android-without-mta:6.8.0` version we currently use was released four years ago and `wechat-sdk-android-without-mta` itself is no longer maintained.

This PR upgrades the WeChat SDK depedency to use `wechat-sdk-android:6.8.34`, the latest available release. The latest WeChat SDK should address the `PendingIntent` compatibility issue on recent Android systems. Since Tencent MTA has been completely deactivated, there should be no concerns around MTA usage.

This PR also adds JitPack support for branch-based consumption, which is useful for testing and debugging, especially for customer-specific validation.